### PR TITLE
[design] 커뮤니티 게시글 상세 페이지 디자인 수정 #110

### DIFF
--- a/app/user/community/[id]/CommunityDetailPage.styled.tsx
+++ b/app/user/community/[id]/CommunityDetailPage.styled.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 
 export const Main = styled.main`
-  padding: 0 1.25rem;
+  padding: 1.25rem;
   display: flex;
   flex-direction: column;
   gap: 0.625rem;

--- a/app/user/community/[id]/components/CommunityPostComment.styled.tsx
+++ b/app/user/community/[id]/components/CommunityPostComment.styled.tsx
@@ -6,19 +6,20 @@ export const CommunityLikeButton = styled.button`
   align-items: center;
   background-color: inherit;
   border: none;
+  cursor: pointer;
 `;
 export const CommunityPostCommentWrapper = styled.section`
   display: flex;
   flex-direction: column;
   gap: 0.625rem;
-  border: 1px solid var(--gray-500);
-  padding: 1rem;
+  border: 0.0625rem solid var(--gray-300);
+  padding: 0.875rem;
   border-radius: 0.625rem;
 `;
 
 export const CommunityPostCommentProfile = styled.div`
-  width: 30px;
-  height: 30px;
+  width: 1.875rem;
+  height: 1.875rem;
   background-color: var(--gray-500);
   border-radius: 50%;
 `;
@@ -27,6 +28,8 @@ export const CommunityPostCommentInfo = styled.div`
   display: flex;
   justify-content: space-between;
   gap: 0.625rem;
+  border-bottom: 0.0625rem solid var(--gray-300);
+  padding-bottom: 0.625rem;
 `;
 
 export const CommunityPostCommentInfoBox = styled.div`
@@ -58,11 +61,26 @@ export const CommunityCommentWrapper = styled.div`
   display: flex;
   flex-direction: row;
   gap: 0.625rem;
+  justify-content: space-between;
 `;
-export const CommunityReply = styled.div`
+export const CommunityCommentBox = styled.div`
   display: flex;
-  gap: 0.3125rem;
+  gap: 1rem;
   align-items: center;
+`;
+
+export const CommunityReplyButton = styled.button`
+  display: flex;
+  gap: 0.625rem;
   background-color: inherit;
   border: none;
+  cursor: pointer;
+`;
+
+export const CommunityPostCommentReply = styled.button`
+  display: flex;
+  gap: 0.3125rem;
+  background-color: inherit;
+  border: none;
+  cursor: pointer;
 `;

--- a/app/user/community/[id]/components/CommunityPostComment.tsx
+++ b/app/user/community/[id]/components/CommunityPostComment.tsx
@@ -7,11 +7,14 @@ import {
   CommunityPostCommentAutor,
   CommunityPostCommentCreated,
   CommunityPostCommentInfoBox,
-  CommunityReply,
+  CommunityCommentBox,
   CommunityCommentWrapper,
   CommunityPostContent,
+  CommunityReplyButton,
+  CommunityPostCommentReply,
 } from "./CommunityPostComment.styled";
 import MoreOptionsMenu from "../../components/MoreOptionMenu";
+
 interface PostsType {
   id: number;
   title: string;
@@ -64,19 +67,35 @@ const CommunityPostComment = ({ post }: CommunityPostContentProps) => {
         댓글내용댓글내용댓글내용댓글내용댓글내용댓글내용댓글내용댓글내용댓글내용댓글내용댓글내용댓글내용댓글내용댓글내용댓글내용
       </CommunityPostContent>
       <CommunityCommentWrapper>
-        <CommunityLikeButton>
+        <CommunityCommentBox>
+          <CommunityLikeButton>
+            <Image
+              src="/icon/heart.svg"
+              alt="좋아요 버튼"
+              width={20}
+              height={20}
+            />
+            {post.likes}
+          </CommunityLikeButton>
+          <CommunityPostCommentReply>
+            <Image
+              src="/icon/talk.svg"
+              alt="답글 버튼"
+              width={20}
+              height={20}
+            />
+            답글
+          </CommunityPostCommentReply>
+        </CommunityCommentBox>
+        <CommunityReplyButton>
           <Image
-            src="/icon/heart.svg"
-            alt="좋아요 버튼"
-            width={20}
-            height={20}
+            src="/icon/dropdown_arrow.svg"
+            alt="답글 화살표"
+            width={15}
+            height={15}
           />
-          {post.likes}
-        </CommunityLikeButton>
-        <CommunityReply>
-          <Image src="/icon/talk.svg" alt="댓글 수" width={20} height={20} />
-          {post.likes}
-        </CommunityReply>
+          답글 {post.commentCount}개
+        </CommunityReplyButton>
       </CommunityCommentWrapper>
     </CommunityPostCommentWrapper>
   );

--- a/app/user/community/[id]/components/CommunityPostContent.styled.tsx
+++ b/app/user/community/[id]/components/CommunityPostContent.styled.tsx
@@ -18,4 +18,5 @@ export const CommunityLikeButton = styled.button`
   align-items: center;
   background-color: inherit;
   border: none;
+  cursor: pointer;
 `;


### PR DESCRIPTION
## 🔘Part

- [x] FE

  <br/>

## 🔎 작업 내용
 - 커뮤니티 게시글 상세페이지에서 댓글 부분 UI 수정 
 - 답글 달기 버튼 추가 및 답글 UI 구현
 - px -> rem 으로 수정
  <br/>

## 이미지 첨부
<img width="436" alt="스크린샷 2025-02-24 오후 9 34 59" src="https://github.com/user-attachments/assets/553c8deb-041c-41a7-9831-75641ac4fc4b" />
- 좋아요 버튼 답글 달기 버튼 답글 개수 및 버튼 추가
<br/>

## 🔧 앞으로의 과제
- 게시글 리스트 불러오기 기능 구현

  <br/>

## ➕ 이슈 링크

- [fungle #110 ]

<br/>
