### PR TITLE
[feat] 로그인 api 구현 #95

### DIFF
--- a/app/(anon)/login/LoginPage.styled.tsx
+++ b/app/(anon)/login/LoginPage.styled.tsx
@@ -19,7 +19,7 @@ export const Logo = styled.img`
 export const FormWrapper = styled.form`
   display: flex;
   flex-direction: column;
-  gap: 2.5rem;
+  gap: 1rem;
   width: 100%;
 `;
 

--- a/app/(anon)/login/LoginPage.styled.tsx
+++ b/app/(anon)/login/LoginPage.styled.tsx
@@ -46,7 +46,6 @@ export const SignupLink = styled(Link)`
 export const ErrorMessage = styled.p`
   font-size: 0.875rem;
   color: var(--error-color);
-  min-height: 1.5rem;
-  margin-top: 0.25rem;
+  min-height: 1.8rem;
   visibility: ${({ children }) => (children ? "visible" : "hidden")};
 `;

--- a/app/(anon)/login/page.tsx
+++ b/app/(anon)/login/page.tsx
@@ -12,8 +12,12 @@ import {
 } from "./LoginPage.styled";
 import { useState } from "react";
 import Button from "@/components/button/Button";
+import { LoginRequestDto } from "@/application/usecases/auth/dto/LoginRequestDto";
+import { useRouter } from "next/navigation";
+import { LoginError } from "@/application/usecases/auth/error/LoginError";
 
 const Page = () => {
+  const router = useRouter();
   const [email, setEmail] = useState("");
   const [emailError, setEmailError] = useState("");
   const [password, setPassword] = useState("");
@@ -26,22 +30,45 @@ const Page = () => {
     );
   };
 
-  const handleLogin = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleLogin = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!email || !password) {
       setLoginError("이메일과 비밀번호를 모두 입력해주세요.");
       return;
     }
-    // 로그인 요청 로직 추가 예정
-    // 로그인 실패 시 setLoginError("유효하지 않은 이메일 또는 비밀번호입니다.");
-    console.log("로그인 요청: ", { email, password });
+
+    try {
+      const request: LoginRequestDto = { userEmail: email, password };
+      const response = await fetch("/api/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(request),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        setLoginError(errorData.error);
+        return;
+      }
+
+      // 로그인 성공 시 토큰 저장
+      console.log("로그인 성공: ", response);
+
+      // 로그인 후 사용자 페이지로 이동
+      router.push("/user/novel");
+    } catch (error) {
+      // setLoginError(
+      //   error instanceof LoginError ? error.message : "로그인 실패"
+      // );
+      console.error("로그인 실패", error);
+      return;
+    }
   };
 
   return (
     <LoginContainer>
       <Logo src="/logo/FUNGLE.svg" />
-      <FormWrapper action="/user/main" onSubmit={handleLogin}>
-        {/* 로그인 백엔드 개발 후 /api/login으로 변경 */}
+      <FormWrapper onSubmit={handleLogin}>
         <InputWrapper>
           <Input
             label="이메일"

--- a/app/api/login/route.ts
+++ b/app/api/login/route.ts
@@ -1,0 +1,75 @@
+import { LoginUsecase } from "@/application/usecases/auth/DfLoginUsecase";
+import { DfPasswordVerificationUsecase } from "@/application/usecases/auth/DfPasswordVerificationUsecase";
+import { LoginRequestDto } from "@/application/usecases/auth/dto/LoginRequestDto";
+import { LoginResponseDto } from "@/application/usecases/auth/dto/LoginResponseDto";
+import {
+  LoginError,
+  LoginErrorType,
+} from "@/application/usecases/auth/error/LoginError";
+import { IPasswordVerifiactionUsecase } from "@/application/usecases/auth/interfaces/IPasswordVerifiactionUsecase";
+import { AuthRepository } from "@/domain/repositories/AuthRepository";
+import { PrAuthRepository } from "@/infrastructure/repositories/PrAuthRepository";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(req: NextRequest) {
+  try {
+    const request: LoginRequestDto = await req.json();
+    const authRepository: AuthRepository = new PrAuthRepository();
+
+    // 비밀번호 비교 usecase
+    const passwordVerificationUsecase: IPasswordVerifiactionUsecase =
+      new DfPasswordVerificationUsecase();
+
+    // LoginUsecase DI
+    const loginUsecase = new LoginUsecase(
+      authRepository,
+      passwordVerificationUsecase
+    );
+
+    // 로그인 실행
+    const loginResponseDto: LoginResponseDto = await loginUsecase.execute(
+      request
+    );
+
+    return NextResponse.json(loginResponseDto, { status: 200 });
+  } catch (error) {
+    console.error("로그인 오류: ", error);
+
+    if (error instanceof LoginError) {
+      const errorMapping: Record<
+        LoginErrorType,
+        { message: string; status: number }
+      > = {
+        MISSING_CREDENTIALS: {
+          message: "이메일과 비밀번호를 모두 입력해주세요.",
+          status: 400,
+        },
+        EMAIL_NOT_FOUND: {
+          message: "가입되지 않은 이메일입니다. 회원가입 후 이용해주세요.",
+          status: 401,
+        },
+        INVALID_PASSWORD: {
+          message: "비밀번호가 올바르지 않습니다. 다시 시도해주세요.",
+          status: 401,
+        },
+
+        UNKNOWN_ERROR: {
+          message: "서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.",
+          status: 500,
+        },
+      };
+
+      const response =
+        errorMapping[error.type] || errorMapping["UNKNOWN_ERROR"];
+      return NextResponse.json(
+        { error: response.message },
+        { status: response.status }
+      );
+    }
+
+    return NextResponse.json(
+      { error: "서버 오류가 발생했습니다." },
+      { status: 500 }
+    );
+  }
+}

--- a/application/usecases/auth/DfLoginUsecase.ts
+++ b/application/usecases/auth/DfLoginUsecase.ts
@@ -1,0 +1,41 @@
+import { LoginRequestDto } from "./dto/LoginRequestDto";
+import { LoginResponseDto } from "./dto/LoginResponseDto";
+import { IPasswordVerifiactionUsecase } from "./interfaces/IPasswordVerifiactionUsecase";
+import { LoginError } from "./error/LoginError";
+import { AuthRepository } from "@/domain/repositories/AuthRepository";
+
+export class LoginUsecase {
+  constructor(
+    private readonly authRepository: AuthRepository,
+    private readonly passwordVerificationUsecase: IPasswordVerifiactionUsecase
+  ) {}
+  async execute(request: LoginRequestDto): Promise<LoginResponseDto> {
+    if (!request.userEmail?.trim() || !request.password?.trim()) {
+      throw new LoginError(
+        "MISSING_CREDENTIALS",
+        "이메일과 비밀번호를 모두 입력해주세요."
+      );
+    }
+
+    const userData = await this.authRepository.findByEmail(request.userEmail);
+
+    if (!userData) {
+      throw new LoginError("EMAIL_NOT_FOUND", "가입되지 않은 이메일입니다.");
+    }
+
+    const { userEmail, password } = userData;
+
+    // 비밀번호 비교
+    const isValidPassword: boolean =
+      await this.passwordVerificationUsecase.execute(
+        request.password,
+        password
+      );
+
+    if (!isValidPassword) {
+      throw new LoginError("INVALID_PASSWORD", "비밀번호가 올바르지 않습니다.");
+    }
+
+    return { userEmail };
+  }
+}

--- a/application/usecases/auth/DfPasswordVerificationUsecase.ts
+++ b/application/usecases/auth/DfPasswordVerificationUsecase.ts
@@ -1,0 +1,11 @@
+import { IPasswordVerifiactionUsecase } from "./interfaces/IPasswordVerifiactionUsecase";
+import bcrypt from "bcrypt";
+
+// 비밀번호 비교 usecase(boolean 값 반환)
+export class DfPasswordVerificationUsecase
+  implements IPasswordVerifiactionUsecase
+{
+  async execute(password: string, hashedPassword: string): Promise<boolean> {
+    return await bcrypt.compare(password, hashedPassword);
+  }
+}

--- a/application/usecases/auth/DfVerifyPasswordUsecase.ts
+++ b/application/usecases/auth/DfVerifyPasswordUsecase.ts
@@ -1,0 +1,25 @@
+// 비밀번호 검증 usecase interface
+import { AuthRepository } from "@/domain/repositories/AuthRepository";
+import { IPasswordVerifiactionUsecase } from "./interfaces/IPasswordVerifiactionUsecase";
+
+export class VerifyPasswordUsecase implements IPasswordVerifiactionUsecase {
+  constructor(
+    private readonly authRepository: AuthRepository,
+    private readonly passwordVerificationUsecase: IPasswordVerifiactionUsecase
+  ) {}
+
+  async execute(email: string, password: string): Promise<boolean> {
+    const userData = await this.authRepository.findByEmail(email);
+    const hashedPassword = userData?.password;
+
+    if (!hashedPassword) throw new Error("비밀번호가 존재하지 않습니다.");
+
+    // 비밀번호 검증
+    const isPasswordValid = await this.passwordVerificationUsecase.execute(
+      password,
+      hashedPassword
+    );
+
+    return isPasswordValid;
+  }
+}

--- a/application/usecases/auth/dto/LoginRequestDto.ts
+++ b/application/usecases/auth/dto/LoginRequestDto.ts
@@ -1,0 +1,4 @@
+export interface LoginRequestDto {
+  userEmail: string;
+  password: string;
+}

--- a/application/usecases/auth/dto/LoginResponseDto.ts
+++ b/application/usecases/auth/dto/LoginResponseDto.ts
@@ -1,0 +1,3 @@
+export interface LoginResponseDto {
+  userEmail: string;
+}

--- a/application/usecases/auth/error/LoginError.ts
+++ b/application/usecases/auth/error/LoginError.ts
@@ -1,0 +1,12 @@
+export type LoginErrorType =
+  | "MISSING_CREDENTIALS"
+  | "EMAIL_NOT_FOUND"
+  | "INVALID_PASSWORD"
+  | "UNKNOWN_ERROR";
+
+export class LoginError extends Error {
+  constructor(public type: LoginErrorType, message: string) {
+    super(message);
+    this.name = "LoginError";
+  }
+}

--- a/application/usecases/auth/interfaces/IPasswordVerifiactionUsecase.ts
+++ b/application/usecases/auth/interfaces/IPasswordVerifiactionUsecase.ts
@@ -1,0 +1,4 @@
+// 비밀번호 비교 usecase interface(boolean 값 반환)
+export interface IPasswordVerifiactionUsecase {
+  execute(password: string, hashedPassword: string): Promise<boolean>;
+}

--- a/application/usecases/auth/interfaces/IVerifyPasswordUsecase.ts
+++ b/application/usecases/auth/interfaces/IVerifyPasswordUsecase.ts
@@ -1,0 +1,4 @@
+// 비밀번호 검증 usecase interface
+export interface IVerifyPasswordUsecase {
+  execute(userId: string, password: string): Promise<boolean>;
+}

--- a/domain/repositories/AuthRepository.ts
+++ b/domain/repositories/AuthRepository.ts
@@ -1,1 +1,14 @@
-// commit test
+import { Prisma } from "@prisma/client";
+
+export interface AuthRepository {
+  findByEmail(email: string): Promise<Prisma.userGetPayload<{
+    select: {
+      id: true;
+      nickname: true;
+      userEmail: true;
+      password: true;
+      createdAt: true;
+      type: true;
+    };
+  }> | null>; // 가입된 사용자가 없는 경우 null 반환
+}

--- a/infrastructure/repositories/PrAuthRepository.ts
+++ b/infrastructure/repositories/PrAuthRepository.ts
@@ -1,1 +1,28 @@
-// commit test
+import { AuthRepository } from "@/domain/repositories/AuthRepository";
+import { prisma } from "../config/prisma";
+import { Prisma } from "@prisma/client";
+
+export class PrAuthRepository implements AuthRepository {
+  async findByEmail(email: string): Promise<Prisma.userGetPayload<{
+    select: {
+      id: true;
+      nickname: true;
+      userEmail: true;
+      password: true;
+      createdAt: true;
+      type: true;
+    };
+  }> | null> {
+    return await prisma.user.findUnique({
+      where: { userEmail: email },
+      select: {
+        id: true,
+        nickname: true,
+        userEmail: true,
+        password: true,
+        createdAt: true,
+        type: true,
+      },
+    });
+  }
+}


### PR DESCRIPTION
## 🔘Part

- [x] BE
  <br/>

## 🔎 작업 내용
- 로그인 api 구현
- 로그인 에러 메시지 표시
- 로그인 성공 시 /novel로 이동
  <br/>

## 이미지 첨부
<img width="327" alt="image" src="https://github.com/user-attachments/assets/cf477f85-be8f-4426-ba4a-1245c2441d1b" />
<img width="356" alt="image" src="https://github.com/user-attachments/assets/771d523f-3e0d-4717-a58a-81d3a7d48097" />


<br/>

## 🔧 앞으로의 과제
토큰 생성 및 쿠키 저장

  <br/>

## ➕ 이슈 링크

- [fungle #95 ]

<br/>
