### PR TITLE
[design] 커뮤니티 수정 페이지 UI 작업 및 컴포넌트 수정 #116

### DIFF
--- a/app/user/community/[id]/CommunityDetailPage.styled.tsx
+++ b/app/user/community/[id]/CommunityDetailPage.styled.tsx
@@ -1,3 +1,4 @@
+"use client";
 import styled from "styled-components";
 
 export const Main = styled.main`

--- a/app/user/community/[id]/components/CommunityPostContent.styled.tsx
+++ b/app/user/community/[id]/components/CommunityPostContent.styled.tsx
@@ -1,3 +1,4 @@
+"use client";
 import styled from "styled-components";
 
 export const CommunityPostContentSection = styled.section`

--- a/app/user/community/[id]/components/CommunityPostHeader.styled.tsx
+++ b/app/user/community/[id]/components/CommunityPostHeader.styled.tsx
@@ -1,3 +1,4 @@
+"use client";
 import styled from "styled-components";
 
 export const CommunityPostHeaderSection = styled.section`

--- a/app/user/community/[id]/components/CommunityPostHeader.tsx
+++ b/app/user/community/[id]/components/CommunityPostHeader.tsx
@@ -1,4 +1,4 @@
-// import { useRouter } from "next/router";
+"use client";
 import MoreOptionsMenu from "../../components/MoreOptionMenu";
 import {
   CommunityPostHeaderSection,
@@ -30,11 +30,6 @@ interface CommunityPostHeaderProps {
 const CommunityPostHeader = ({ post }: CommunityPostHeaderProps) => {
   // const router = useRouter();
 
-  const handleEdit = () => {
-    console.log("수정 기능 호출");
-    // 수정 페이지 이동 로직 추가
-  };
-
   const handleDelete = async () => {
     if (confirm("정말 삭제하시겠습니까?")) {
       console.log("삭제 기능 호출");
@@ -46,7 +41,7 @@ const CommunityPostHeader = ({ post }: CommunityPostHeaderProps) => {
       <CommunityPostInfo>
         <CommunityPostTitle>{post.title}</CommunityPostTitle>
 
-        <MoreOptionsMenu onEdit={handleEdit} onDelete={handleDelete} />
+        <MoreOptionsMenu onDelete={handleDelete} postId={post.id} />
       </CommunityPostInfo>
       <div>
         <p>{post.author}</p>

--- a/app/user/community/[id]/edit/CommunityEditPage.styled.tsx
+++ b/app/user/community/[id]/edit/CommunityEditPage.styled.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import styled from "styled-components";
+
+export const Main = styled.main`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  overflow-y: auto;
+  padding: 0 1.25rem 1.25rem 1.25rem;
+  margin-top: 1.25rem;
+`;

--- a/app/user/community/[id]/edit/components/CommunityPostEditForm.styled.tsx
+++ b/app/user/community/[id]/edit/components/CommunityPostEditForm.styled.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import styled from "styled-components";
+
+export const Form = styled.form`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  overflow-y: auto;
+  padding: 0 1.25rem 1.25rem 1.25rem;
+  margin-top: 1.25rem;
+`;
+export const ButtonBox = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  gap: 0.625rem;
+`;
+
+export const TextAreaWrapper = styled.section`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+`;

--- a/app/user/community/[id]/edit/components/CommunityPostEditForm.tsx
+++ b/app/user/community/[id]/edit/components/CommunityPostEditForm.tsx
@@ -1,0 +1,79 @@
+"use client";
+import Button from "@/components/button/Button";
+import Dropdown from "@/components/dropdown/Dropdown";
+import Input from "@/components/input/Input";
+import Textarea from "@/components/textarea/Textarea";
+import { RECRUITMENT_FIELDS } from "@/constants/RECRUITMENT_FIELDS";
+
+import { useState } from "react";
+import {
+  ButtonBox,
+  TextAreaWrapper,
+  Form,
+} from "./CommunityPostEditForm.styled";
+
+const CommunityPostEditForm = () => {
+  const [selectedFields, setSelectedFields] = useState<string[]>([]);
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+
+  const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setTitle(value);
+  };
+
+  const handleSelect = (value: string) => {
+    const option = RECRUITMENT_FIELDS.find((option) => option.value === value);
+    if (!option) return;
+
+    if (selectedFields.includes(option.value)) {
+      setSelectedFields((prev) =>
+        prev.filter((value) => value !== option.value)
+      );
+    } else {
+      setSelectedFields((prev) => [...prev, option.value]);
+    }
+  };
+
+  const handleChangeContent = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const { value } = e.target;
+    setContent(value);
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    console.log("title:", title, "content", content);
+  };
+
+  return (
+    <Form onSubmit={handleSubmit}>
+      <div>
+        <Input
+          label="제목"
+          hideLabel={true}
+          placeholder="제목을 입력해주세요"
+          onChange={handleTitleChange}
+        />
+      </div>
+
+      <Dropdown
+        options={RECRUITMENT_FIELDS}
+        onSelect={handleSelect}
+        selected={selectedFields}
+      />
+      <TextAreaWrapper>
+        <Textarea
+          ariaLabel="게시글 내용"
+          onChange={handleChangeContent}
+          height="100%"
+        />
+        <ButtonBox>
+          <Button backgroudColor={"white"}>취소</Button>
+          <Button>작성</Button>
+        </ButtonBox>
+      </TextAreaWrapper>
+    </Form>
+  );
+};
+
+export default CommunityPostEditForm;

--- a/app/user/community/[id]/edit/page.tsx
+++ b/app/user/community/[id]/edit/page.tsx
@@ -1,1 +1,12 @@
-// commit test
+import CommunityPostEditForm from "./components/CommunityPostEditForm";
+
+const Page = async ({ params }: { params: Promise<{ id: string }> }) => {
+  const postId = (await params).id;
+
+  console.log(postId);
+  // postId로 해당 게시글 가져오기
+
+  return <CommunityPostEditForm />;
+};
+
+export default Page;

--- a/app/user/community/[id]/page.tsx
+++ b/app/user/community/[id]/page.tsx
@@ -1,23 +1,19 @@
-"use client";
-
 import { posts } from "../components/CommunityPostList";
 
-import { use } from "react";
 import { Main } from "./CommunityDetailPage.styled";
-import Input from "@/components/input/Input";
 
 import CommunityPostHeader from "./components/CommunityPostHeader";
 import CommunityPostContent from "./components/CommunityPostContent";
-import CommunityPostComment from "./components/CommunityPostComment";
+import CommentCreate from "@/components/comment/CommentCreate";
+import Comment from "@/components/comment/Comment";
 
 interface PageParams {
   params: Promise<{ id: string }>;
 }
 
-const Page = ({ params }: PageParams) => {
-  const resolvedParams = use(params);
-  const { id } = resolvedParams;
-  const post = posts.find((p) => p.id.toString() === id);
+const Page = async ({ params }: PageParams) => {
+  const postId = (await params).id;
+  const post = posts.find((p) => p.id.toString() === postId);
 
   if (!post) {
     return <main>게시글을 찾을 수 없습니다.</main>;
@@ -28,16 +24,9 @@ const Page = ({ params }: PageParams) => {
 
       <CommunityPostContent post={post} />
 
-      <section>
-        <p>댓글 {post.commentCount}</p>
-        <Input
-          label="댓글 입력"
-          placeholder="댓글을 입력해주세요."
-          hideLabel={true}
-        />
-      </section>
+      <CommentCreate post={post} />
 
-      <CommunityPostComment post={post} />
+      <Comment post={post} />
     </Main>
   );
 };

--- a/app/user/community/components/CommunityListFilter.styled.tsx
+++ b/app/user/community/components/CommunityListFilter.styled.tsx
@@ -1,3 +1,4 @@
+"use client";
 import styled from "styled-components";
 
 export const ListFilterWrapper = styled.div`

--- a/app/user/community/components/CommunityPagination.styled.tsx
+++ b/app/user/community/components/CommunityPagination.styled.tsx
@@ -1,3 +1,4 @@
+"use client";
 import styled from "styled-components";
 
 export const PaginationWrapper = styled.nav`

--- a/app/user/community/components/CommunityPostList.styled.tsx
+++ b/app/user/community/components/CommunityPostList.styled.tsx
@@ -1,3 +1,4 @@
+"use client";
 import styled from "styled-components";
 
 export const PostListContainer = styled.ul`

--- a/app/user/community/components/CommunitySearchFilter.styled.tsx
+++ b/app/user/community/components/CommunitySearchFilter.styled.tsx
@@ -1,3 +1,4 @@
+"use client";
 import styled from "styled-components";
 export const Section = styled.section`
   display: flex;

--- a/app/user/community/components/MoreOptionMenu.styled.tsx
+++ b/app/user/community/components/MoreOptionMenu.styled.tsx
@@ -1,3 +1,4 @@
+"use client";
 import styled from "styled-components";
 
 export const Wrapper = styled.div`
@@ -23,6 +24,22 @@ export const Dropdown = styled.div`
 `;
 
 export const MenuItem = styled.button`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.875rem;
+
+  &:hover {
+    background: var(--gray-100);
+  }
+`;
+
+export const EditBox = styled.div`
   width: 100%;
   display: flex;
   align-items: center;

--- a/app/user/community/components/MoreOptionMenu.tsx
+++ b/app/user/community/components/MoreOptionMenu.tsx
@@ -8,14 +8,16 @@ import {
   MenuItem,
   MoreButton,
   Wrapper,
+  EditBox,
 } from "./MoreOptionMenu.styled";
+import Link from "next/link";
 
 interface MoreOptionsMenuProps {
-  onEdit: () => void;
   onDelete: () => void;
+  postId?: number;
 }
 
-const MoreOptionsMenu = ({ onEdit, onDelete }: MoreOptionsMenuProps) => {
+const MoreOptionsMenu = ({ onDelete, postId }: MoreOptionsMenuProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
@@ -55,10 +57,17 @@ const MoreOptionsMenu = ({ onEdit, onDelete }: MoreOptionsMenuProps) => {
       </MoreButton>
       {isOpen && (
         <Dropdown>
-          <MenuItem onClick={onEdit}>
-            <Image src="/icon/edit_pen.svg" alt="수정" width={20} height={20} />
-            수정
-          </MenuItem>
+          <Link href={`/user/community/${postId}/edit/`}>
+            <EditBox>
+              <Image
+                src="/icon/edit_pen.svg"
+                alt="수정"
+                width={20}
+                height={20}
+              />
+              수정
+            </EditBox>
+          </Link>
           <MenuItem onClick={onDelete}>
             <Image src="/icon/delete.svg" alt="삭제" width={20} height={20} />
             삭제

--- a/components/button/Button.styled.tsx
+++ b/components/button/Button.styled.tsx
@@ -1,3 +1,4 @@
+"use client";
 import styled from "styled-components";
 
 interface ButtonProps {

--- a/components/comment/Comment.styled.tsx
+++ b/components/comment/Comment.styled.tsx
@@ -1,3 +1,4 @@
+"use client";
 import styled from "styled-components";
 
 export const CommunityLikeButton = styled.button`

--- a/components/comment/Comment.tsx
+++ b/components/comment/Comment.tsx
@@ -1,3 +1,4 @@
+"use client";
 import Image from "next/image";
 import {
   CommunityLikeButton,
@@ -12,8 +13,8 @@ import {
   CommunityPostContent,
   CommunityReplyButton,
   CommunityPostCommentReply,
-} from "./CommunityPostComment.styled";
-import MoreOptionsMenu from "../../components/MoreOptionMenu";
+} from "./Comment.styled";
+import MoreOptionsMenu from "@/app/user/community/components/MoreOptionMenu";
 
 interface PostsType {
   id: number;
@@ -32,14 +33,10 @@ interface PostsType {
 interface CommunityPostContentProps {
   post: PostsType;
 }
-const CommunityPostComment = ({ post }: CommunityPostContentProps) => {
+const Comment = ({ post }: CommunityPostContentProps) => {
   if (!post) {
     return <main>게시글을 찾을 수 없습니다.</main>;
   }
-  const handleEdit = () => {
-    console.log("수정 기능 호출");
-    // 수정 페이지 이동 로직 추가
-  };
 
   const handleDelete = async () => {
     if (confirm("정말 삭제하시겠습니까?")) {
@@ -60,7 +57,7 @@ const CommunityPostComment = ({ post }: CommunityPostContentProps) => {
           </div>
         </CommunityPostCommentInfoBox>
 
-        <MoreOptionsMenu onEdit={handleEdit} onDelete={handleDelete} />
+        <MoreOptionsMenu onDelete={handleDelete} />
       </CommunityPostCommentInfo>
 
       <CommunityPostContent>
@@ -101,4 +98,4 @@ const CommunityPostComment = ({ post }: CommunityPostContentProps) => {
   );
 };
 
-export default CommunityPostComment;
+export default Comment;

--- a/components/comment/CommentCreate.tsx
+++ b/components/comment/CommentCreate.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import Input from "../input/Input";
+
+interface PostsType {
+  id: number;
+  title: string;
+  status: string;
+  genre: string;
+  author: string;
+  content: string;
+  time: string;
+  likes: number;
+  views: number;
+  commentCount: number;
+  createdAt: string;
+}
+interface CommunityPostContentProps {
+  post: PostsType;
+}
+
+const CommentCreate = ({ post }: CommunityPostContentProps) => {
+  return (
+    <section>
+      <p>댓글 {post.commentCount}</p>
+      <Input
+        label="댓글 입력"
+        placeholder="댓글을 입력해주세요."
+        hideLabel={true}
+      />
+    </section>
+  );
+};
+
+export default CommentCreate;

--- a/components/dropdown/Dropdown.styled.tsx
+++ b/components/dropdown/Dropdown.styled.tsx
@@ -1,3 +1,4 @@
+"use client";
 import styled from "styled-components";
 
 export interface StyledItemProps {

--- a/components/dropdown/Dropdown.tsx
+++ b/components/dropdown/Dropdown.tsx
@@ -1,5 +1,11 @@
 import { Menu, MenuButton, MenuItems, MenuItem } from "@headlessui/react";
-import { DropdownWrapper, StyledButton, StyledMenu, StyledItem, DropdownArrow } from "@/components/dropdown/Dropdown.styled";
+import {
+  DropdownWrapper,
+  StyledButton,
+  StyledMenu,
+  StyledItem,
+  DropdownArrow,
+} from "@/components/dropdown/Dropdown.styled";
 
 interface Option {
   value: string;
@@ -9,12 +15,26 @@ interface Option {
 interface DropdownProps {
   options: Option[];
   onSelect: (value: string) => void;
-  selected: string;
+  selected: string | string[];
   size?: "default" | "small";
 }
 
-const Dropdown = ({ options, onSelect, selected, size = "default" }: DropdownProps) => {
-  const selectedLabel = options.find((option) => option.value === selected)?.label || "선택하세요";
+const Dropdown = ({
+  options,
+  onSelect,
+  selected,
+  size = "default",
+}: DropdownProps) => {
+  const selectedLabel = Array.isArray(selected)
+    ? selected
+        .map(
+          (value) =>
+            options.find((option) => option.value === value)?.label || ""
+        )
+        .filter((value) => value)
+        .join(", ") || "선택하세요"
+    : options.find((option) => option.label === selected)?.label ||
+      "선택하세요";
 
   return (
     <DropdownWrapper size={size}>
@@ -23,7 +43,10 @@ const Dropdown = ({ options, onSelect, selected, size = "default" }: DropdownPro
           <div>
             <MenuButton as={StyledButton} size={size}>
               {selectedLabel}
-              <DropdownArrow src="/icon/dropdown_arrow.svg" alt="dropdown arrow" />
+              <DropdownArrow
+                src="/icon/dropdown_arrow.svg"
+                alt="dropdown arrow"
+              />
             </MenuButton>
             {open && (
               <MenuItems as={StyledMenu}>

--- a/components/header/Header.styled.tsx
+++ b/components/header/Header.styled.tsx
@@ -1,3 +1,4 @@
+"use client";
 import styled from "styled-components";
 
 export const HeaderWrapper = styled.header`

--- a/components/input/Input.styled.tsx
+++ b/components/input/Input.styled.tsx
@@ -1,3 +1,4 @@
+"use client";
 import styled from "styled-components";
 
 export const Container = styled.div`

--- a/components/modal/Modal.styled.tsx
+++ b/components/modal/Modal.styled.tsx
@@ -1,3 +1,4 @@
+"use client";
 import styled from "styled-components";
 
 export const ModalOverlay = styled.div`

--- a/components/sidebar/Sidebar.styled.tsx
+++ b/components/sidebar/Sidebar.styled.tsx
@@ -1,3 +1,4 @@
+"use client";
 import styled, { keyframes } from "styled-components";
 
 const slideIn = keyframes`
@@ -25,8 +26,6 @@ export const SidebarContainer = styled.div<{ $isOpen: boolean }>`
   animation: ${({ $isOpen }) => ($isOpen ? slideIn : "none")} 0.7s forwards;
   z-index: 1000;
 `;
-
-
 
 export const SidebarHeader = styled.div`
   display: flex;

--- a/components/textarea/Textarea.styled.tsx
+++ b/components/textarea/Textarea.styled.tsx
@@ -1,3 +1,4 @@
+"use client";
 import styled from "styled-components";
 
 interface StyledProps {

--- a/components/textarea/Textarea.tsx
+++ b/components/textarea/Textarea.tsx
@@ -6,6 +6,7 @@ interface TextareaProps {
   height?: string;
   defaultValue?: string;
   ariaLabel: string;
+  onChange?: React.ChangeEventHandler<HTMLTextAreaElement>;
 }
 
 const Textarea = ({
@@ -14,6 +15,7 @@ const Textarea = ({
   height = "60vh",
   defaultValue,
   ariaLabel,
+  onChange,
 }: TextareaProps) => {
   return (
     <>
@@ -24,6 +26,7 @@ const Textarea = ({
         height={height}
         defaultValue={defaultValue}
         aria-label={ariaLabel}
+        onChange={onChange}
       />
     </>
   );


### PR DESCRIPTION
## 🔘Part

- [x] FE

  <br/>

## 🔎 작업 내용
- 커뮤니티 수정 페이지 UI 작업 및 컴포넌트 분리.
- 기존 공통 컴포넌트 및 사용중인 커뮤니티 컴포넌트 `styled.tsx` 파일에 "use client" 추가
- `Dropdown` 컴포넌트 1개씩만 적용 -> 여러 값 적용으로 수정 
- <img width="432" alt="스크린샷 2025-02-25 오후 2 17 17" src="https://github.com/user-attachments/assets/afa62beb-78e1-465a-bfea-876b222bbd32" />
- `Textarea` 컴포넌트 `onChange` props 추가
  <br/>



## 이미지 첨부
<img width="463" alt="스크린샷 2025-02-25 오후 2 18 06" src="https://github.com/user-attachments/assets/4e50e965-b6d4-4fa4-a14b-af82670d304b" />

<br/>

## 🔧 앞으로의 과제


  <br/>

## ➕ 이슈 링크

- [fungle #116 ]

<br/>
