### PR TITLE
[design] 버튼 컴포넌트에 xsmall 크기 추가 #169

### DIFF
--- a/components/button/Button.styled.tsx
+++ b/components/button/Button.styled.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 
 interface ButtonProps {
   $fontSize?: "big" | "medium" | "small";
-  $buttonSize?: "big" | "medium" | "small";
+  $buttonSize?: "big" | "medium" | "small" | "xsmall";
   $backgroundColor?: "primary" | "white" | "leave";
   disabled?: boolean;
 }
@@ -28,13 +28,17 @@ export const ButtonComponent = styled.button<ButtonProps>`
   border: ${(props) =>
     props.$backgroundColor === "white" ? "1px solid var(--gray-500)" : "none"};
   cursor: pointer;
-  padding: 0.625rem 0;
+  /* padding: 0.625rem 0; */
+  padding: ${(props) =>
+    props.$buttonSize === "xsmall" ? "0.3rem 0" : "0.625rem 0"};
   width: ${(props) =>
     props.$buttonSize === "big"
       ? "100%"
       : props.$buttonSize === "medium"
       ? "15.313rem"
-      : "6.25rem"};
+      : props.$buttonSize === "small"
+      ? "6.25rem"
+      : "3rem"};
   font-size: var(--font-size-placeholder);
 
   &:disabled {

--- a/components/button/Button.tsx
+++ b/components/button/Button.tsx
@@ -2,7 +2,7 @@ import { ButtonComponent } from "./Button.styled";
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   fontSize?: "big" | "medium" | "small";
-  buttonSize?: "big" | "medium" | "small";
+  buttonSize?: "big" | "medium" | "small" | "xsmall";
   backgroudColor?: "primary" | "white" | "leave";
   disabled?: boolean;
   children?: React.ReactNode;


### PR DESCRIPTION
## 🔘Part

- [x] FE

  <br/>

## 🔎 작업 내용
버튼 컴포넌트의 buttonSize에 xsmall 크기 추가
  <br/>

## 이미지 첨부

<br/>

## 🔧 앞으로의 과제


  <br/>

## ➕ 이슈 링크

- [fungle #169 ]

<br/>
