### PR TITLE
[feat] 커뮤니티 상세 페이지 DB 연동

### DIFF
--- a/app/api/community/[id]/comments/route.ts
+++ b/app/api/community/[id]/comments/route.ts
@@ -1,0 +1,32 @@
+import { DfPostDetailCommentUsecase } from "@/application/usecases/community/DfPostDetailCommentUsecase";
+import { PrCommunityCommentRepository } from "@/infrastructure/repositories/PrCommunityCommentRepository";
+import { NextRequest, NextResponse } from "next/server";
+
+export const GET = async (
+  requets: NextRequest,
+  { params }: { params: { id: number } }
+) => {
+  const { id } = params;
+  if (!id) return "ID가 없습니다.";
+  try {
+    const commentPostRepository = new PrCommunityCommentRepository();
+    const postCommentUsecase = new DfPostDetailCommentUsecase(
+      commentPostRepository
+    );
+
+    const comments = await postCommentUsecase.execute(id);
+
+    return NextResponse.json(comments);
+  } catch (error: unknown) {
+    let message = "Unknown error";
+    let status = 500;
+    if (error instanceof Error) {
+      message = error.message;
+      const typedError = error as { status?: number };
+      if (typedError.status) {
+        status = typedError.status;
+      }
+    }
+    return NextResponse.json({ error: message }, { status });
+  }
+};

--- a/app/api/community/[id]/route.ts
+++ b/app/api/community/[id]/route.ts
@@ -1,1 +1,39 @@
-//commit
+import { DfPostDetailUsecase } from "@/application/usecases/community/DfPostDetailUsecase";
+
+import { PrCommunityPostRepository } from "@/infrastructure/repositories/PrCommunityPostRepository";
+import { PrUserRepository } from "@/infrastructure/repositories/PrUserRepository";
+import { NextRequest, NextResponse } from "next/server";
+
+export const GET = async (
+  requets: NextRequest,
+  { params }: { params: { id: number } }
+) => {
+  const { id } = params;
+
+  if (!id) return "ID가 없습니다.";
+
+  try {
+    const communityPostRepository = new PrCommunityPostRepository();
+    const userRepository = new PrUserRepository();
+
+    const postDetailUsecase = new DfPostDetailUsecase(
+      communityPostRepository,
+      userRepository
+    );
+
+    const postDetail = await postDetailUsecase.execute(id);
+
+    return NextResponse.json(postDetail);
+  } catch (error: unknown) {
+    let message = "Unknown error";
+    let status = 500;
+    if (error instanceof Error) {
+      message = error.message;
+      const typedError = error as { status?: number };
+      if (typedError.status) {
+        status = typedError.status;
+      }
+    }
+    return NextResponse.json({ error: message }, { status });
+  }
+};

--- a/app/user/community/[id]/components/CommunityPostContent.tsx
+++ b/app/user/community/[id]/components/CommunityPostContent.tsx
@@ -1,3 +1,4 @@
+import { CommunityPost } from "@prisma/client";
 import {
   CommunityPostContentSection,
   CommunityPostLikeButtonBox,
@@ -5,30 +6,22 @@ import {
 } from "./CommunityPostContent.styled";
 import Image from "next/image";
 
-interface PostsType {
-  id: number;
-  title: string;
-  status: string;
-  genre: string;
-  author: string;
-  content: string;
-  time: string;
+type CommunityPostWithNicknameAndLikes = CommunityPost & {
+  userNickname: string;
   likes: number;
-  views: number;
-  commentCount: number;
-  createdAt: string;
+};
+
+interface CommunityPostHeaderProps {
+  postDetail: CommunityPostWithNicknameAndLikes;
 }
 
-interface CommunityPostContentProps {
-  post: PostsType;
-}
-const CommunityPostContent = ({ post }: CommunityPostContentProps) => {
-  if (!post) {
+const CommunityPostContent = ({ postDetail }: CommunityPostHeaderProps) => {
+  if (!postDetail) {
     return <main>게시글을 찾을 수 없습니다.</main>;
   }
   return (
     <CommunityPostContentSection>
-      {post.content}
+      {postDetail.content}
       <CommunityPostLikeButtonBox>
         <CommunityLikeButton>
           <Image
@@ -37,7 +30,7 @@ const CommunityPostContent = ({ post }: CommunityPostContentProps) => {
             width={20}
             height={20}
           />
-          {post.likes}
+          {postDetail.likes}
         </CommunityLikeButton>
       </CommunityPostLikeButtonBox>
     </CommunityPostContentSection>

--- a/app/user/community/[id]/components/CommunityPostHeader.tsx
+++ b/app/user/community/[id]/components/CommunityPostHeader.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { CommunityPost } from "@prisma/client";
 import MoreOptionsMenu from "../../components/MoreOptionMenu";
 import {
   CommunityPostHeaderSection,
@@ -8,46 +9,41 @@ import {
   CommunityPostview,
   CommunityPostTitle,
 } from "./CommunityPostHeader.styled";
+import { formatDate } from "@/utils/date/formatDate";
 
-interface PostsType {
-  id: number;
-  title: string;
-  status: string;
-  genre: string;
-  author: string;
-  content: string;
-  time: string;
-  likes: number;
-  views: number;
-  commentCount: number;
-  createdAt: string;
-}
+type CommunityPostWithNickname = CommunityPost & {
+  userNickname: string;
+};
 
 interface CommunityPostHeaderProps {
-  post: PostsType;
+  postDetail: CommunityPostWithNickname;
 }
-
-const CommunityPostHeader = ({ post }: CommunityPostHeaderProps) => {
-  // const router = useRouter();
-
+const CommunityPostHeader = ({ postDetail }: CommunityPostHeaderProps) => {
   const handleDelete = async () => {
     if (confirm("정말 삭제하시겠습니까?")) {
       console.log("삭제 기능 호출");
       // API 요청 또는 useCase 실행
     }
   };
+
+  if (!postDetail) return null;
+  const createdAt = new Date(postDetail.createdAt);
+
+  const createdAtFormatted = formatDate(createdAt);
   return (
     <CommunityPostHeaderSection>
       <CommunityPostInfo>
-        <CommunityPostTitle>{post.title}</CommunityPostTitle>
+        <CommunityPostTitle>{postDetail.title}</CommunityPostTitle>
 
-        <MoreOptionsMenu onDelete={handleDelete} postId={post.id} />
+        <MoreOptionsMenu onDelete={handleDelete} postId={postDetail.id} />
       </CommunityPostInfo>
       <div>
-        <p>{post.author}</p>
+        <p>{postDetail.userNickname}</p>
         <CommunityPostStats>
-          <CommunityPostCreated>작성일 {post.createdAt}</CommunityPostCreated>
-          <CommunityPostview>조회수 {post.views}</CommunityPostview>
+          <CommunityPostCreated>
+            작성일 {createdAtFormatted}
+          </CommunityPostCreated>
+          <CommunityPostview>조회수 {postDetail.view}</CommunityPostview>
         </CommunityPostStats>
       </div>
     </CommunityPostHeaderSection>

--- a/app/user/community/[id]/page.tsx
+++ b/app/user/community/[id]/page.tsx
@@ -1,5 +1,3 @@
-import { posts } from "../components/CommunityPostList";
-
 import { Main } from "./CommunityDetailPage.styled";
 
 import CommunityPostHeader from "./components/CommunityPostHeader";
@@ -13,20 +11,37 @@ interface PageParams {
 
 const Page = async ({ params }: PageParams) => {
   const postId = (await params).id;
-  const post = posts.find((p) => p.id.toString() === postId);
 
-  if (!post) {
-    return <main>게시글을 찾을 수 없습니다.</main>;
+  let post;
+  try {
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_BASE_URL}/api/community/${postId}`,
+      {
+        cache: "no-store",
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch post: ${response.status}`);
+    }
+
+    post = await response.json();
+  } catch (error: unknown) {
+    let errorMessage = "게시글을 찾는 중 알 수 없는 오류가 발생했습니다.";
+    if (error instanceof Error) {
+      errorMessage = error.message;
+    }
+    return <main>{errorMessage}</main>;
   }
   return (
     <Main>
-      <CommunityPostHeader post={post} />
+      <CommunityPostHeader postDetail={post} />
 
-      <CommunityPostContent post={post} />
+      <CommunityPostContent postDetail={post} />
 
       <CommentCreate post={post} />
 
-      <Comment post={post} />
+      <Comment postId={postId} />
     </Main>
   );
 };

--- a/application/usecases/community/DfPostDetailCommentUsecase.ts
+++ b/application/usecases/community/DfPostDetailCommentUsecase.ts
@@ -1,8 +1,8 @@
-import { PrCommunityCommentRepository } from "@/infrastructure/repositories/PrCommunityCommentRepository";
+import { CommunityCommentRepository } from "@/domain/repositories/CommunityCommentRepository";
 import { PostDetailCommentsWithUserDto } from "./dto/PostDetailCommentsWithUserDto";
 
 export class DfPostDetailCommentUsecase {
-  constructor(private communityPostRepository: PrCommunityCommentRepository) {}
+  constructor(private communityPostRepository: CommunityCommentRepository) {}
 
   async execute(id: number): Promise<PostDetailCommentsWithUserDto[]> {
     try {

--- a/application/usecases/community/DfPostDetailCommentUsecase.ts
+++ b/application/usecases/community/DfPostDetailCommentUsecase.ts
@@ -1,9 +1,10 @@
 import { PrCommunityCommentRepository } from "@/infrastructure/repositories/PrCommunityCommentRepository";
+import { PostDetailCommentsWithUserDto } from "./dto/PostDetailCommentsWithUserDto";
 
 export class DfPostDetailCommentUsecase {
   constructor(private communityPostRepository: PrCommunityCommentRepository) {}
 
-  async execute(id: number) {
+  async execute(id: number): Promise<PostDetailCommentsWithUserDto[]> {
     try {
       const comments = await this.communityPostRepository.findAll(id);
 

--- a/application/usecases/community/DfPostDetailCommentUsecase.ts
+++ b/application/usecases/community/DfPostDetailCommentUsecase.ts
@@ -1,0 +1,32 @@
+import { PrCommunityCommentRepository } from "@/infrastructure/repositories/PrCommunityCommentRepository";
+
+export class DfPostDetailCommentUsecase {
+  constructor(private communityPostRepository: PrCommunityCommentRepository) {}
+
+  async execute(id: number) {
+    try {
+      const comments = await this.communityPostRepository.findAll(id);
+
+      const flatComments = comments.map((comment) => ({
+        id: comment.id,
+        userId: comment.userId,
+        comment: comment.comment,
+        createdAt: comment.createdAt,
+        parentId: comment.parentId ?? 0,
+        postId: comment.postId,
+        userNickname: comment.user.nickname,
+        profileImage: comment.user.profileImage,
+        likes: comment._count.communityCommentLikes,
+        // replies: comment._count?.replies ?? 0,
+      }));
+
+      return flatComments;
+    } catch (error: unknown) {
+      let message = "Unknown error";
+      if (error instanceof Error) {
+        message = error.message;
+      }
+      throw new Error(`댓글 데이터를 가져오는 데 실패했습니다: ${message}`);
+    }
+  }
+}

--- a/application/usecases/community/DfPostDetailUsecase.ts
+++ b/application/usecases/community/DfPostDetailUsecase.ts
@@ -1,0 +1,44 @@
+import { PrCommunityPostRepository } from "@/infrastructure/repositories/PrCommunityPostRepository";
+import { PrUserRepository } from "@/infrastructure/repositories/PrUserRepository";
+import { PostWithLikesAndUserNicknameDto } from "./dto/CommunityPostWithNicknameAndLikesDto";
+
+export class DfPostDetailUsecase {
+  constructor(
+    private postRepository: PrCommunityPostRepository,
+    private userRepository: PrUserRepository
+  ) {}
+
+  async execute(id: number): Promise<PostWithLikesAndUserNicknameDto> {
+    try {
+      const post = await this.postRepository.findPost(id);
+
+      if (!post) {
+        throw new Error("Post not found");
+      }
+
+      const user = await this.userRepository.getUserById(post?.userId);
+
+      const postDetail = {
+        id: post.id,
+        content: post.content,
+        createdAt: post.createdAt,
+        status: post.status,
+        title: post.title,
+        userId: post.userId,
+        view: post.view,
+        userNickname: user?.nickname,
+        likes: post._count?.communityPostLikes || 0,
+      };
+
+      return postDetail;
+    } catch (error: unknown) {
+      let message = "Unknown error";
+      if (error instanceof Error) {
+        message = error.message;
+      }
+      throw new Error(
+        `게시글 상세 정보를 가져오는 데 실패했습니다: ${message}`
+      );
+    }
+  }
+}

--- a/application/usecases/community/DfPostDetailUsecase.ts
+++ b/application/usecases/community/DfPostDetailUsecase.ts
@@ -1,11 +1,11 @@
-import { PrCommunityPostRepository } from "@/infrastructure/repositories/PrCommunityPostRepository";
-import { PrUserRepository } from "@/infrastructure/repositories/PrUserRepository";
+import { CommunityPostRepository } from "@/domain/repositories/CommunityPostRepository";
 import { PostWithLikesAndUserNicknameDto } from "./dto/CommunityPostWithNicknameAndLikesDto";
+import { UserRepository } from "@/domain/repositories/UserRepository";
 
 export class DfPostDetailUsecase {
   constructor(
-    private postRepository: PrCommunityPostRepository,
-    private userRepository: PrUserRepository
+    private postRepository: CommunityPostRepository,
+    private userRepository: UserRepository
   ) {}
 
   async execute(id: number): Promise<PostWithLikesAndUserNicknameDto> {

--- a/application/usecases/community/DfPostListUsecase.ts
+++ b/application/usecases/community/DfPostListUsecase.ts
@@ -1,5 +1,5 @@
-import { PrCommunityPostRepository } from "@/infrastructure/repositories/PrCommunityPostRepository";
 import { PostWithCountAndRecruitmentDto } from "./dto/PostWithCountAndRecruitmentDto";
+import { CommunityPostRepository } from "@/domain/repositories/CommunityPostRepository";
 
 export interface GetCommunityPostsParams {
   page: number;
@@ -17,7 +17,7 @@ export interface PostListResult {
 }
 
 export class DfPostListUsecase {
-  constructor(private postRepository: PrCommunityPostRepository) {}
+  constructor(private CommunityPostRepository: CommunityPostRepository) {}
 
   async execute({
     page = 1,
@@ -30,9 +30,7 @@ export class DfPostListUsecase {
   }: GetCommunityPostsParams): Promise<PostListResult> {
     const offset = (page - 1) * limit;
 
-    const communityPostRepository = new PrCommunityPostRepository();
-
-    const posts = await communityPostRepository.findAll({
+    const posts = await this.CommunityPostRepository.findAll({
       limit,
       offset,
       filter,
@@ -42,7 +40,7 @@ export class DfPostListUsecase {
       recruitment,
     });
 
-    const totalCount = await communityPostRepository.count({
+    const totalCount = await this.CommunityPostRepository.count({
       filter,
       searchField,
       search,

--- a/application/usecases/community/dto/CommunityPostWithNicknameAndLikesDto.ts
+++ b/application/usecases/community/dto/CommunityPostWithNicknameAndLikesDto.ts
@@ -1,0 +1,6 @@
+import { CommunityPost } from "@prisma/client";
+
+export interface PostWithLikesAndUserNicknameDto extends CommunityPost {
+  userNickname?: string;
+  likes?: number;
+}

--- a/application/usecases/community/dto/PostDetailCommentsWithUserDto.ts
+++ b/application/usecases/community/dto/PostDetailCommentsWithUserDto.ts
@@ -1,0 +1,7 @@
+import { CommunityComment } from "@prisma/client";
+
+export interface PostDetailCommentsWithUserDto extends CommunityComment {
+  userNickname: string;
+  profileImage?: string | null;
+  likes?: number;
+}

--- a/components/comment/Comment.styled.tsx
+++ b/components/comment/Comment.styled.tsx
@@ -23,6 +23,8 @@ export const CommunityPostCommentProfile = styled.div`
   height: 1.875rem;
   background-color: var(--gray-500);
   border-radius: 50%;
+  position: relative;
+  overflow: hidden;
 `;
 
 export const CommunityPostCommentInfo = styled.div`

--- a/domain/repositories/CommunityCommentRepository.ts
+++ b/domain/repositories/CommunityCommentRepository.ts
@@ -1,1 +1,5 @@
-// commit test
+import { CommunityComment } from "@prisma/client";
+
+export interface CommunityCommentRepository {
+  findAll(postId: number): Promise<CommunityComment[]>;
+}

--- a/domain/repositories/CommunityCommentRepository.ts
+++ b/domain/repositories/CommunityCommentRepository.ts
@@ -1,5 +1,21 @@
-import { CommunityComment } from "@prisma/client";
+import { Prisma } from "@prisma/client";
+
+export type CommentWithRelations = Prisma.CommunityCommentGetPayload<{
+  include: {
+    user: {
+      select: {
+        nickname: true;
+        profileImage: true;
+      };
+    };
+    _count: {
+      select: {
+        communityCommentLikes: true;
+      };
+    };
+  };
+}>;
 
 export interface CommunityCommentRepository {
-  findAll(postId: number): Promise<CommunityComment[]>;
+  findAll(postId: number): Promise<CommentWithRelations[]>;
 }

--- a/domain/repositories/CommunityPostRepository.ts
+++ b/domain/repositories/CommunityPostRepository.ts
@@ -1,15 +1,35 @@
-import { CommunityPost } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 
+export type PostWithRelations = Prisma.CommunityPostGetPayload<{
+  include: {
+    user: {
+      select: { nickname: true };
+    };
+    _count: { select: { communityPostLikes: true; communityComments: true } };
+    PostRecruitments: { include: { RecruitmentCategory: true } };
+  };
+}>;
+
+export type PostWithPostLikes = Prisma.CommunityPostGetPayload<{
+  include: {
+    _count: {
+      select: {
+        communityPostLikes: true;
+        communityComments: true;
+      };
+    };
+  };
+}>;
 export interface CommunityPostRepository {
   findAll(params: {
     limit: number;
     offset: number;
-    filter: string;
+    filter?: string;
     sort: string;
     searchField: string;
-    search: string;
-    recruitment: string;
-  }): Promise<CommunityPost[]>;
+    search?: string;
+    recruitment?: string;
+  }): Promise<PostWithRelations[]>;
 
   count(params: {
     filter?: string;
@@ -18,5 +38,5 @@ export interface CommunityPostRepository {
     recruitment?: string;
   }): Promise<number>;
 
-  findPost(id: number): Promise<CommunityPost | null>;
+  findPost(id: number): Promise<PostWithPostLikes | null>;
 }

--- a/domain/repositories/CommunityPostRepository.ts
+++ b/domain/repositories/CommunityPostRepository.ts
@@ -17,4 +17,6 @@ export interface CommunityPostRepository {
     search?: string;
     recruitment?: string;
   }): Promise<number>;
+
+  findPost(id: number): Promise<CommunityPost | null>;
 }

--- a/infrastructure/repositories/PrCommunityCommentRepository.ts
+++ b/infrastructure/repositories/PrCommunityCommentRepository.ts
@@ -1,10 +1,13 @@
-import { CommunityCommentRepository } from "@/domain/repositories/CommunityCommentRepository";
+import {
+  CommentWithRelations,
+  CommunityCommentRepository,
+} from "@/domain/repositories/CommunityCommentRepository";
 import { prisma } from "../config/prisma";
 
 export class PrCommunityCommentRepository
   implements CommunityCommentRepository
 {
-  async findAll(id: number) {
+  async findAll(id: number): Promise<CommentWithRelations[]> {
     const postId = Number(id);
     try {
       const comments = await prisma.communityComment.findMany({

--- a/infrastructure/repositories/PrCommunityCommentRepository.ts
+++ b/infrastructure/repositories/PrCommunityCommentRepository.ts
@@ -1,1 +1,33 @@
-// commit test
+import { CommunityCommentRepository } from "@/domain/repositories/CommunityCommentRepository";
+import { prisma } from "../config/prisma";
+
+export class PrCommunityCommentRepository
+  implements CommunityCommentRepository
+{
+  async findAll(id: number) {
+    const postId = Number(id);
+    try {
+      const comments = await prisma.communityComment.findMany({
+        where: { postId: postId },
+        include: {
+          user: {
+            select: {
+              nickname: true,
+              profileImage: true,
+            },
+          },
+          _count: {
+            select: {
+              communityCommentLikes: true,
+              // replies: true,
+            },
+          },
+        },
+      });
+
+      return comments;
+    } catch {
+      throw new Error("댓글 데이터를 가져오는 데 실패했습니다.");
+    }
+  }
+}

--- a/infrastructure/repositories/PrCommunityPostRepository.ts
+++ b/infrastructure/repositories/PrCommunityPostRepository.ts
@@ -1,27 +1,10 @@
-import { CommunityPostRepository } from "@/domain/repositories/CommunityPostRepository";
+import {
+  CommunityPostRepository,
+  PostWithPostLikes,
+  PostWithRelations,
+} from "@/domain/repositories/CommunityPostRepository";
 import { Prisma } from "@prisma/client";
 import { prisma } from "../config/prisma";
-
-type PostWithRelations = Prisma.CommunityPostGetPayload<{
-  include: {
-    user: {
-      select: { nickname: true };
-    };
-    _count: { select: { communityPostLikes: true; communityComments: true } };
-    PostRecruitments: { include: { RecruitmentCategory: true } };
-  };
-}>;
-
-type PostWithPostLikes = Prisma.CommunityPostGetPayload<{
-  include: {
-    _count: {
-      select: {
-        communityPostLikes: true;
-        communityComments: true;
-      };
-    };
-  };
-}>;
 
 export class PrCommunityPostRepository implements CommunityPostRepository {
   async findAll(params: {

--- a/infrastructure/repositories/PrCommunityPostRepository.ts
+++ b/infrastructure/repositories/PrCommunityPostRepository.ts
@@ -12,6 +12,17 @@ type PostWithRelations = Prisma.CommunityPostGetPayload<{
   };
 }>;
 
+type PostWithPostLikes = Prisma.CommunityPostGetPayload<{
+  include: {
+    _count: {
+      select: {
+        communityPostLikes: true;
+        communityComments: true;
+      };
+    };
+  };
+}>;
+
 export class PrCommunityPostRepository implements CommunityPostRepository {
   async findAll(params: {
     limit: number;
@@ -72,31 +83,35 @@ export class PrCommunityPostRepository implements CommunityPostRepository {
       };
     }
 
-    const posts = await prisma.communityPost.findMany({
-      where: whereClause,
-      skip: params.offset,
-      take: params.limit,
-      orderBy: orderBy,
-      include: {
-        user: {
-          select: { nickname: true },
-        },
+    try {
+      const posts = await prisma.communityPost.findMany({
+        where: whereClause,
+        skip: params.offset,
+        take: params.limit,
+        orderBy: orderBy,
+        include: {
+          user: {
+            select: { nickname: true },
+          },
 
-        _count: {
-          select: {
-            communityPostLikes: true,
-            communityComments: true,
+          _count: {
+            select: {
+              communityPostLikes: true,
+              communityComments: true,
+            },
+          },
+          PostRecruitments: {
+            include: {
+              RecruitmentCategory: true,
+            },
           },
         },
-        PostRecruitments: {
-          include: {
-            RecruitmentCategory: true,
-          },
-        },
-      },
-    });
+      });
 
-    return posts;
+      return posts;
+    } catch {
+      throw new Error("게시글 리스트를 가져오는 데 실패했습니다.");
+    }
   }
 
   async count(params: {
@@ -137,7 +152,30 @@ export class PrCommunityPostRepository implements CommunityPostRepository {
         },
       };
     }
+    try {
+      return await prisma.communityPost.count({ where: whereClause });
+    } catch {
+      throw new Error("게시글 개수를 가져오는 데 실패했습니다.");
+    }
+  }
 
-    return await prisma.communityPost.count({ where: whereClause });
+  async findPost(id: number): Promise<PostWithPostLikes | null> {
+    const postId = Number(id);
+    try {
+      const post = await prisma.communityPost.findUnique({
+        where: { id: postId },
+        include: {
+          _count: {
+            select: {
+              communityPostLikes: true,
+              communityComments: true,
+            },
+          },
+        },
+      });
+      return post;
+    } catch {
+      throw new Error("게시글 상세 정보를 가져오는 데 실패했습니다.");
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@headlessui/react": "^2.2.0",
         "@prisma/client": "^6.4.0",
         "bcrypt": "^5.1.1",
+        "date-fns": "^4.1.0",
         "jsonwebtoken": "^9.0.2",
         "next": "15.1.7",
         "nodemailer": "^6.10.0",
@@ -2388,6 +2389,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@headlessui/react": "^2.2.0",
     "@prisma/client": "^6.4.0",
     "bcrypt": "^5.1.1",
+    "date-fns": "^4.1.0",
     "jsonwebtoken": "^9.0.2",
     "next": "15.1.7",
     "nodemailer": "^6.10.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,7 +13,9 @@ model CommunityComment {
   createdAt             DateTime               @default(now())
   userId                String
   postId                Int
-  parentId              String?
+  parentId              Int?
+  parent                CommunityComment?      @relation("CommentReplies", fields: [parentId], references: [id])
+  replies               CommunityComment[]     @relation("CommentReplies")
   communityPost         CommunityPost          @relation("CommunityComments", fields: [postId], references: [id], onDelete: Cascade)
   user                  User                   @relation("UserCommunityComments", fields: [userId], references: [id], onDelete: Cascade)
   communityCommentLikes CommunityCommentLike[] @relation("CommunityCommentLikes")

--- a/utils/date/formatDate.ts
+++ b/utils/date/formatDate.ts
@@ -1,0 +1,5 @@
+import { format } from "date-fns";
+
+export const formatDate = (dateString: Date) => {
+  return format(dateString, "yyyy-MM-dd HH:mm");
+};


### PR DESCRIPTION
## 🔘Part

- [x] FE

  <br/>

## 🔎 작업 내용
- 커뮤니티 상세 페이지 DB 연동
- 해당 게시글 postId 로 DB에 게시글을 유저 정보와 댓글 개수, 좋아요 개수를 불러와 DB 연동
- 댓글 컴포넌트에서 postId로 DB에 댓글리스트를 불러와 클라이언트에 연동
  <br/>

## 이미지 첨부
<img width="491" alt="스크린샷 2025-02-28 오후 1 42 08" src="https://github.com/user-attachments/assets/70bb2d7c-cdf6-43d0-aff4-28dda9177e1a" />

<br/>

## 🔧 앞으로의 과제


  <br/>

## ➕ 이슈 링크

- [fungle #35 ]

<br/>
