### PR TITLE
[feat]  커뮤니티 게시글 답글 카운트 추가 DB 연동#173

### DIFF
--- a/application/usecases/community/DfPostDetailCommentUsecase.ts
+++ b/application/usecases/community/DfPostDetailCommentUsecase.ts
@@ -13,12 +13,12 @@ export class DfPostDetailCommentUsecase {
         userId: comment.userId,
         comment: comment.comment,
         createdAt: comment.createdAt,
-        parentId: comment.parentId ?? 0,
+        parentId: comment.parentId ?? null,
         postId: comment.postId,
         userNickname: comment.user.nickname,
         profileImage: comment.user.profileImage,
         likes: comment._count.communityCommentLikes,
-        // replies: comment._count?.replies ?? 0,
+        replies: comment.replies ? comment.replies.length : 0,
       }));
 
       return flatComments;

--- a/application/usecases/community/dto/PostDetailCommentsWithUserDto.ts
+++ b/application/usecases/community/dto/PostDetailCommentsWithUserDto.ts
@@ -4,4 +4,6 @@ export interface PostDetailCommentsWithUserDto extends CommunityComment {
   userNickname: string;
   profileImage?: string | null;
   likes?: number;
+
+  replies?: number;
 }

--- a/components/comment/Comment.tsx
+++ b/components/comment/Comment.tsx
@@ -23,6 +23,7 @@ type CommentsWithNickname = CommunityComment & {
   userNickname: string;
   profileImage: string;
   likes: number;
+  replies: number | 0;
 };
 
 const Comment = ({ postId }: { postId: string }) => {
@@ -42,7 +43,6 @@ const Comment = ({ postId }: { postId: string }) => {
 
         setComments(comments);
       } catch (error: unknown) {
-        console.error(error);
         if (error instanceof Error) {
           setError(error.message);
         } else {
@@ -134,7 +134,7 @@ const Comment = ({ postId }: { postId: string }) => {
                   width={15}
                   height={15}
                 />
-                답글 0개
+                답글 {comment.replies}개
               </CommunityReplyButton>
             </CommunityCommentWrapper>
           </CommunityPostCommentWrapper>

--- a/domain/repositories/CommunityCommentRepository.ts
+++ b/domain/repositories/CommunityCommentRepository.ts
@@ -2,6 +2,7 @@ import { Prisma } from "@prisma/client";
 
 export type CommentWithRelations = Prisma.CommunityCommentGetPayload<{
   include: {
+    replies: true;
     user: {
       select: {
         nickname: true;

--- a/infrastructure/repositories/PrCommunityCommentRepository.ts
+++ b/infrastructure/repositories/PrCommunityCommentRepository.ts
@@ -13,6 +13,7 @@ export class PrCommunityCommentRepository
       const comments = await prisma.communityComment.findMany({
         where: { postId: postId },
         include: {
+          replies: true,
           user: {
             select: {
               nickname: true,
@@ -22,7 +23,6 @@ export class PrCommunityCommentRepository
           _count: {
             select: {
               communityCommentLikes: true,
-              // replies: true,
             },
           },
         },


### PR DESCRIPTION
## 🔘Part

- [x] FE

  <br/>

## 🔎 작업 내용
- 커뮤니티 게시글 상세페이지 댓글 컴포넌트에 답글 개수를 DB와 연동하여 추가하였습니다.
  <br/>

## 이미지 첨부
<img width="341" alt="스크린샷 2025-02-28 오후 3 07 11" src="https://github.com/user-attachments/assets/59a5dea6-90b9-4e54-9090-5718f3fcdb79" />

<br/>

## 🔧 앞으로의 과제


  <br/>

## ➕ 이슈 링크

- [fungle #173 ]

<br/>
