### PR TITLE
[feat] 커뮤니티 게시글 수정 기능 구현 #32

### DIFF
--- a/app/api/community/[id]/edit/route.ts
+++ b/app/api/community/[id]/edit/route.ts
@@ -1,0 +1,32 @@
+import { DfGetPostWithRecruitmentsUsecase } from "@/application/usecases/community/DfGetPostWithRecruitmentsUsecase";
+import { PrCommunityPostRepository } from "@/infrastructure/repositories/PrCommunityPostRepository";
+
+import { NextRequest, NextResponse } from "next/server";
+
+export const GET = async (
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) => {
+  const { id } = await params;
+
+  if (!id) return "ID가 없습니다.";
+
+  try {
+    const communityPostRepository = new PrCommunityPostRepository();
+    const getPostWithRecruitmentsUsecase = new DfGetPostWithRecruitmentsUsecase(
+      communityPostRepository
+    );
+    const postWithRecruitments = await getPostWithRecruitmentsUsecase.execute(
+      id
+    );
+
+    return NextResponse.json(postWithRecruitments);
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      return NextResponse.json(
+        { error: error.message || "게시글 불러오기 실패" },
+        { status: 500 }
+      );
+    }
+  }
+};

--- a/app/api/community/[id]/update/route.ts
+++ b/app/api/community/[id]/update/route.ts
@@ -1,0 +1,55 @@
+import { DfVerifyRefreshToken } from "@/application/usecases/auth/DfVerifyRefreshToken";
+import { DfPostUpdateUsecase } from "@/application/usecases/community/DfPostUpdateUsecase";
+import { UserRepository } from "@/domain/repositories/UserRepository";
+import { PrCommunityPostRepository } from "@/infrastructure/repositories/PrCommunityPostRepository";
+import { PrUserRepository } from "@/infrastructure/repositories/PrUserRepository";
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+
+export const PUT = async (
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) => {
+  try {
+    const { id } = await params;
+    const body = await request.json();
+
+    const cookieStore = await cookies();
+    const refreshToken = cookieStore.get("refreshToken")?.value;
+
+    if (!refreshToken) {
+      return NextResponse.json({ error: "No refresh token" }, { status: 401 });
+    }
+
+    const { title, content, fields } = body;
+
+    const userRepository: UserRepository = new PrUserRepository();
+    const verifyRefreshTokenUsecase = new DfVerifyRefreshToken(userRepository);
+    const verifiedUser = await verifyRefreshTokenUsecase.execute(refreshToken);
+
+    if (!verifiedUser) {
+      return NextResponse.json({ user: null }, { status: 401 });
+    }
+
+    const { userId } = verifiedUser;
+
+    const communityPostRepository = new PrCommunityPostRepository();
+    const postCreateUsecase = new DfPostUpdateUsecase(communityPostRepository);
+    const postId = await postCreateUsecase.execute(
+      userId,
+      id,
+      title,
+      content,
+      fields
+    );
+
+    return NextResponse.json(postId);
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      return NextResponse.json(
+        { error: error.message || "게시글 수정 실패" },
+        { status: 500 }
+      );
+    }
+  }
+};

--- a/app/user/community/[id]/edit/components/CommunityEdit.styled.tsx
+++ b/app/user/community/[id]/edit/components/CommunityEdit.styled.tsx
@@ -1,0 +1,12 @@
+import styled from "styled-components";
+
+export const ErrorMessage = styled.p`
+  color: var(--error-color);
+  text-align: center;
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--font-size-xxl);
+  font-weight: 600;
+`;

--- a/app/user/community/[id]/edit/components/CommunityEdit.tsx
+++ b/app/user/community/[id]/edit/components/CommunityEdit.tsx
@@ -67,7 +67,7 @@ const CommunityEdit = ({ postId }: { postId: string }) => {
       router.push(`/user/community/${updatedPostId}`);
     } catch (error: unknown) {
       if (error instanceof Error) {
-        alert(`게시글 수정 실패: ${error.message}`);
+        alert(`게시글 수정 실패 원인: ${error.message}`);
       } else {
         alert("게시글 수정 중 알 수 없는 오류가 발생했습니다.");
       }

--- a/app/user/community/[id]/edit/components/CommunityEdit.tsx
+++ b/app/user/community/[id]/edit/components/CommunityEdit.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useMemo, useState } from "react";
 import CommunityPostForm from "../../../components/CommunityPostForm";
 import { useRouter } from "next/navigation";
+import { ErrorMessage } from "./CommunityEdit.styled";
 
 type PostData = {
   title: string;
@@ -10,6 +11,7 @@ type PostData = {
 };
 const CommunityEdit = ({ postId }: { postId: string }) => {
   const [postData, setPostData] = useState<PostData | null>(null);
+  const [errorMessage, setErrorMessage] = useState("");
   const router = useRouter();
 
   useEffect(() => {
@@ -28,7 +30,15 @@ const CommunityEdit = ({ postId }: { postId: string }) => {
           content: postData.content,
           fields: postData.recruitmentNames,
         });
-      } catch {}
+      } catch (error: unknown) {
+        if (error instanceof Error) {
+          setErrorMessage(error.message);
+        } else {
+          setErrorMessage(
+            "게시글을 불러오는 중 알 수 없는 오류가 발생했습니다."
+          );
+        }
+      }
     };
 
     fetchPostData();
@@ -75,13 +85,19 @@ const CommunityEdit = ({ postId }: { postId: string }) => {
   };
 
   return (
-    <CommunityPostForm
-      mode="edit"
-      initalTitle={postData?.title}
-      initalContent={postData?.content}
-      initalSelectedFields={initialSelectedFields}
-      onSubmit={handleEdit}
-    />
+    <>
+      {errorMessage ? (
+        <ErrorMessage>{errorMessage}</ErrorMessage>
+      ) : (
+        <CommunityPostForm
+          mode="edit"
+          initalTitle={postData?.title}
+          initalContent={postData?.content}
+          initalSelectedFields={initialSelectedFields}
+          onSubmit={handleEdit}
+        />
+      )}
+    </>
   );
 };
 

--- a/app/user/community/[id]/edit/components/CommunityEdit.tsx
+++ b/app/user/community/[id]/edit/components/CommunityEdit.tsx
@@ -1,0 +1,88 @@
+"use client";
+import { useEffect, useMemo, useState } from "react";
+import CommunityPostForm from "../../../components/CommunityPostForm";
+import { useRouter } from "next/navigation";
+
+type PostData = {
+  title: string;
+  content: string;
+  fields: string[];
+};
+const CommunityEdit = ({ postId }: { postId: string }) => {
+  const [postData, setPostData] = useState<PostData | null>(null);
+  const router = useRouter();
+
+  useEffect(() => {
+    const fetchPostData = async () => {
+      try {
+        const response = await fetch(`/api/community/${postId}/edit`);
+
+        if (!response.ok) {
+          throw new Error("서버 오류");
+        }
+
+        const postData = await response.json();
+
+        setPostData({
+          title: postData.title,
+          content: postData.content,
+          fields: postData.recruitmentNames,
+        });
+      } catch {}
+    };
+
+    fetchPostData();
+  }, [postId]);
+
+  const initialSelectedFields = useMemo(() => {
+    return postData?.fields || [];
+  }, [postData?.fields]);
+
+  const handleEdit = async (
+    title: string,
+    content: string,
+    fields: string[]
+  ) => {
+    try {
+      const response = await fetch(`/api/community/${postId}/update`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          title,
+          content,
+          fields,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error("게시글 수정 실패");
+      }
+
+      const { postId: updatedPostId } = await response.json();
+
+      alert("게시글이 수정되었습니다.상세 페이지로 이동합니다.");
+
+      router.push(`/user/community/${updatedPostId}`);
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        alert(`게시글 수정 실패: ${error.message}`);
+      } else {
+        alert("게시글 수정 중 알 수 없는 오류가 발생했습니다.");
+      }
+    }
+  };
+
+  return (
+    <CommunityPostForm
+      mode="edit"
+      initalTitle={postData?.title}
+      initalContent={postData?.content}
+      initalSelectedFields={initialSelectedFields}
+      onSubmit={handleEdit}
+    />
+  );
+};
+
+export default CommunityEdit;

--- a/app/user/community/[id]/edit/page.tsx
+++ b/app/user/community/[id]/edit/page.tsx
@@ -1,12 +1,9 @@
-import CommunityPostForm from "../../components/CommunityPostForm";
+import CommunityEdit from "./components/CommunityEdit";
 
 const Page = async ({ params }: { params: Promise<{ id: string }> }) => {
   const postId = (await params).id;
 
-  console.log(postId);
-  // postId로 해당 게시글 가져오기
-
-  return <CommunityPostForm />;
+  return <CommunityEdit postId={postId} />;
 };
 
 export default Page;

--- a/app/user/community/components/CommunityPostForm.tsx
+++ b/app/user/community/components/CommunityPostForm.tsx
@@ -7,6 +7,7 @@ import { RECRUITMENT_FIELDS } from "@/constants/RECRUITMENT_FIELDS";
 
 import { useEffect, useState } from "react";
 import { ButtonBox, TextAreaWrapper, Form } from "./CommunityPostForm.styled";
+import { ErrorMessage } from "../[id]/edit/components/CommunityEdit.styled";
 
 type CommunityPostFormProps = {
   mode: "create" | "edit";
@@ -92,36 +93,39 @@ const CommunityPostForm = ({
 
   return (
     <>
-      {errorMessage && <div>{errorMessage}</div>}
-      <Form onSubmit={handleSubmit}>
-        <div>
-          <Input
-            label="제목"
-            hideLabel={true}
-            placeholder="제목을 입력해주세요"
-            onChange={handleTitleChange}
-            value={title}
-          />
-        </div>
+      {errorMessage ? (
+        <ErrorMessage>{errorMessage}</ErrorMessage>
+      ) : (
+        <Form onSubmit={handleSubmit}>
+          <div>
+            <Input
+              label="제목"
+              hideLabel={true}
+              placeholder="제목을 입력해주세요"
+              onChange={handleTitleChange}
+              value={title}
+            />
+          </div>
 
-        <Dropdown
-          options={RECRUITMENT_FIELDS}
-          onSelect={handleSelect}
-          selected={selectedFields}
-        />
-        <TextAreaWrapper>
-          <Textarea
-            ariaLabel="게시글 내용"
-            onChange={handleChangeContent}
-            height="100%"
-            defaultValue={content}
+          <Dropdown
+            options={RECRUITMENT_FIELDS}
+            onSelect={handleSelect}
+            selected={selectedFields}
           />
-          <ButtonBox>
-            <Button backgroudColor={"white"}>취소</Button>
-            <Button>{mode === "create" ? "작성" : "수정"}</Button>
-          </ButtonBox>
-        </TextAreaWrapper>
-      </Form>
+          <TextAreaWrapper>
+            <Textarea
+              ariaLabel="게시글 내용"
+              onChange={handleChangeContent}
+              height="100%"
+              defaultValue={content}
+            />
+            <ButtonBox>
+              <Button backgroudColor={"white"}>취소</Button>
+              <Button>{mode === "create" ? "작성" : "수정"}</Button>
+            </ButtonBox>
+          </TextAreaWrapper>
+        </Form>
+      )}
     </>
   );
 };

--- a/app/user/community/components/CommunityPostForm.tsx
+++ b/app/user/community/components/CommunityPostForm.tsx
@@ -68,6 +68,17 @@ const CommunityPostForm = ({
     if (!title || !content || selectedFields.length === 0) {
       return alert("모든 값을 입력해주세요");
     }
+
+    const isTitleSame = title === initalTitle;
+    const isContentSame = content === initalContent;
+    const isFieldsSame =
+      JSON.stringify([...selectedFields].sort()) ===
+      JSON.stringify([...initalSelectedFields].sort());
+
+    if (isTitleSame && isContentSame && isFieldsSame) {
+      return alert("변경된 내용이 없습니다.");
+    }
+
     try {
       await onSubmit(title, content, selectedFields);
     } catch (error: unknown) {

--- a/app/user/community/create/page.tsx
+++ b/app/user/community/create/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useRouter } from "next/navigation";
 import CommunityPostForm from "../components/CommunityPostForm";
+import { useMemo } from "react";
 
 const Page = () => {
   const router = useRouter();
@@ -40,6 +41,10 @@ const Page = () => {
     }
   };
 
+  const memoizedSelectedFields = useMemo(() => {
+    return [];
+  }, []);
+
   return (
     <CommunityPostForm
       mode="create"
@@ -61,6 +66,7 @@ const Page = () => {
     
     광고성 게시글 및 폭력, 혐오, 사회 분열을 조장하는 글은 경고 없이 관리자에 의해 삭제됩니다.
       `}
+      initalSelectedFields={memoizedSelectedFields}
       onSubmit={handleCreate}
     />
   );

--- a/application/usecases/community/DfGetPostWithRecruitmentsUsecase.ts
+++ b/application/usecases/community/DfGetPostWithRecruitmentsUsecase.ts
@@ -1,0 +1,36 @@
+import { CommunityPostRepository } from "@/domain/repositories/CommunityPostRepository";
+import { GetPostWithRecruitmentsDto } from "./dto/GetPostWithRecruitmentsDto";
+
+export class DfGetPostWithRecruitmentsUsecase {
+  constructor(private postRepository: CommunityPostRepository) {}
+
+  async execute(id: string): Promise<GetPostWithRecruitmentsDto> {
+    try {
+      const postWithRecruitments = await this.postRepository.findPost(id);
+
+      if (!postWithRecruitments) {
+        throw new Error("Post not found");
+      }
+
+      const flatPostWithRecruitments = {
+        content: postWithRecruitments.content,
+        createdAt: postWithRecruitments.createdAt,
+        id: postWithRecruitments.id,
+        status: postWithRecruitments.status,
+        title: postWithRecruitments.title,
+        userId: postWithRecruitments.userId,
+        view: postWithRecruitments.view,
+        recruitmentNames: postWithRecruitments.PostRecruitments.map(
+          (pr) => pr.RecruitmentCategory.name
+        ),
+      };
+      return flatPostWithRecruitments;
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        throw new Error(`게시글 조회에 실패했습니다. 원인: ${error.message}`);
+      }
+
+      throw new Error("게시글 조회에 실패했습니다.");
+    }
+  }
+}

--- a/application/usecases/community/DfPostDetailUsecase.ts
+++ b/application/usecases/community/DfPostDetailUsecase.ts
@@ -10,7 +10,7 @@ export class DfPostDetailUsecase {
 
   async execute(id: number): Promise<PostWithLikesAndUserNicknameDto> {
     try {
-      const post = await this.postRepository.findPost(id);
+      const post = await this.postRepository.findPostWithPostLike(id);
 
       if (!post) {
         throw new Error("Post not found");

--- a/application/usecases/community/DfPostUpdateUsecase.ts
+++ b/application/usecases/community/DfPostUpdateUsecase.ts
@@ -1,0 +1,31 @@
+import { CommunityPostRepository } from "@/domain/repositories/CommunityPostRepository";
+import { PostUpdateDto } from "./dto/PostUpdateDto";
+
+export class DfPostUpdateUsecase {
+  constructor(private communityPostRepository: CommunityPostRepository) {}
+
+  async execute(
+    userId: string,
+    id: string,
+    title: string,
+    content: string,
+    selectedFields: string[]
+  ): Promise<PostUpdateDto> {
+    try {
+      const postId = await this.communityPostRepository.updatePost(
+        userId,
+        id,
+        title,
+        content,
+        selectedFields
+      );
+
+      return { postId };
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        throw new Error(`게시글 수정에 실패했습니다. 원인: ${error.message}`);
+      }
+      throw new Error("게시글 수정에 실패했습니다.");
+    }
+  }
+}

--- a/application/usecases/community/dto/GetPostWithRecruitmentsDto.ts
+++ b/application/usecases/community/dto/GetPostWithRecruitmentsDto.ts
@@ -1,0 +1,5 @@
+import { CommunityPost } from "@prisma/client";
+
+export interface GetPostWithRecruitmentsDto extends CommunityPost {
+  recruitmentNames: string[];
+}

--- a/application/usecases/community/dto/PostUpdateDto.ts
+++ b/application/usecases/community/dto/PostUpdateDto.ts
@@ -1,0 +1,3 @@
+export interface PostUpdateDto {
+  postId: number;
+}

--- a/domain/repositories/CommunityPostRepository.ts
+++ b/domain/repositories/CommunityPostRepository.ts
@@ -20,6 +20,12 @@ export type PostWithPostLikes = Prisma.CommunityPostGetPayload<{
     };
   };
 }>;
+
+export type PostWithRecruitments = Prisma.CommunityPostGetPayload<{
+  include: {
+    PostRecruitments: { include: { RecruitmentCategory: true } };
+  };
+}>;
 export interface CommunityPostRepository {
   findAll(params: {
     limit: number;
@@ -38,12 +44,22 @@ export interface CommunityPostRepository {
     recruitment?: string;
   }): Promise<number>;
 
-  findPost(id: number): Promise<PostWithPostLikes | null>;
+  findPostWithPostLike(id: number): Promise<PostWithPostLikes | null>;
 
   createPost(
     userId: string,
     title: string,
     content: string,
     selectedFeilds: string[]
+  ): Promise<number>;
+
+  findPost(id: string): Promise<PostWithRecruitments | null>;
+
+  updatePost(
+    userId: string,
+    id: string,
+    title: string,
+    content: string,
+    selectedFields: string[]
   ): Promise<number>;
 }


### PR DESCRIPTION
## 🔘Part

- [x] FE

  <br/>

## 🔎 작업 내용
- 커뮤니티 상세페이지에서 수정 버튼 클릭 시 해당 게시글 내용을 받아오며,
- 내용 수정 후 해당 수정 버튼 클릭 시 DB에 update 진행
- 완료 후 해당 게시글 상세페이지로 이동
  <br/>

## 이미지 첨부



https://github.com/user-attachments/assets/57c11da8-cc54-4fa6-b065-25acbb75f871



<br/>





## 🔧 앞으로의 과제
- 게시글 삭제 기능 구현

  <br/>

## ➕ 이슈 링크

- [fungle #32 ]

<br/>
