### PR TITLE
[fix]소설 페이지 장르,연재일, 연재상태 영어 -> 한글 전환 #203

### DIFF
--- a/app/user/novel/[novelId]/page.tsx
+++ b/app/user/novel/[novelId]/page.tsx
@@ -6,6 +6,9 @@ import Image from "next/image";
 import { useParams } from "next/navigation";
 import { NovelDto } from "@/application/usecases/novel/dto/Novel"; 
 import { Main, GradientWrapper, NovelHeader, StatusSection, Badge, UploadInfo, AuthorSection, EpisodeItem } from "@/app/user/novel/[novelId]/NovelIdPage.styled";
+import { GENRES } from "@/constants/GENRES";
+import { SERIAL_STATUS } from "@/constants/STATUS";
+import { SERIAL_DAY } from "@/constants/SERIAL_DAY";
 
 const Page = () => {
   const params = useParams();
@@ -41,8 +44,25 @@ const Page = () => {
             .replace(/\. /g, ".")
             .replace(/\.$/, ""),
         }));
+        
 
-        setNovel({ ...data, episodes: formattedEpisodes });
+        const serialStatusLabel =
+        SERIAL_STATUS.find((status) => status.value === data.serialStatus)?.label || data.serialStatus;
+
+      const serialDayLabel =
+        SERIAL_DAY.find((day) => day.value === data.serialDay)?.label || data.serialDay;
+
+      const genreLabels = data.genres.map(
+        (genre) => GENRES.find((g) => g.value === genre)?.label || genre
+      );
+
+      setNovel({
+        ...data,
+        serialStatus: serialStatusLabel,
+        serialDay: serialDayLabel,
+        genres: genreLabels,
+        episodes: formattedEpisodes,
+      });
       } catch (error) {
         console.error("Error fetching novel:", error);
         setError("소설 정보를 불러오는 중 오류가 발생했습니다.");


### PR DESCRIPTION
## 🔘Part

- [x] FE

  <br/>

## 🔎 작업 내용

  <br/>

## 이미지 첨부
![image](https://github.com/user-attachments/assets/c46491fb-a4eb-4949-ad0e-4adde59bb179)
-> 
![image](https://github.com/user-attachments/assets/4cb2ae74-2b5e-4491-95ae-7fb73af97b26)


<br/>

## 🔧 앞으로의 과제
novel episode approved 상태일때만  UI 표시 


  <br/>

## ➕ 이슈 링크

- [fungle #203 ]

<br/>
