### PR TITLE
[feat] 커뮤니티 게시글 삭제 기능 구현 #33

### DIFF
--- a/app/api/community/[id]/route.ts
+++ b/app/api/community/[id]/route.ts
@@ -1,7 +1,10 @@
+import { DfVerifyRefreshToken } from "@/application/usecases/auth/DfVerifyRefreshToken";
+import { DfPostDeleteUsecase } from "@/application/usecases/community/DfPostDeleteUsecase";
 import { DfPostDetailUsecase } from "@/application/usecases/community/DfPostDetailUsecase";
 
 import { PrCommunityPostRepository } from "@/infrastructure/repositories/PrCommunityPostRepository";
 import { PrUserRepository } from "@/infrastructure/repositories/PrUserRepository";
+import { cookies } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
 
 export const GET = async (
@@ -35,5 +38,49 @@ export const GET = async (
       }
     }
     return NextResponse.json({ error: message }, { status });
+  }
+};
+
+export const DELETE = async (
+  requets: NextRequest,
+  { params }: { params: { id: string } }
+) => {
+  try {
+    const { id } = await params;
+
+    if (!id) return "ID가 없습니다.";
+
+    const cookieStore = await cookies();
+    const refreshToken = cookieStore.get("refreshToken")?.value;
+
+    if (!refreshToken) {
+      return NextResponse.json({ error: "No refresh token" }, { status: 401 });
+    }
+
+    const userRepository = new PrUserRepository();
+    const verifyRefreshTokenUsecase = new DfVerifyRefreshToken(userRepository);
+    const verifiedUser = await verifyRefreshTokenUsecase.execute(refreshToken);
+    if (!verifiedUser) {
+      return NextResponse.json({ user: null }, { status: 401 });
+    }
+    const { id: userId } = verifiedUser;
+
+    const communityPostRepository = new PrCommunityPostRepository();
+    const postDeleteUsecase = new DfPostDeleteUsecase(communityPostRepository);
+
+    const isDelete = await postDeleteUsecase.execute(id, userId);
+
+    if (!isDelete) {
+      return NextResponse.json(
+        { error: "게시글 삭제에 실패했습니다." },
+        { status: 400 }
+      );
+    }
+
+    return NextResponse.json({ isDelete }, { status: 200 });
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      return NextResponse.json({ error: error.message });
+    }
   }
 };

--- a/app/api/community/[id]/update/route.ts
+++ b/app/api/community/[id]/update/route.ts
@@ -1,6 +1,5 @@
 import { DfVerifyRefreshToken } from "@/application/usecases/auth/DfVerifyRefreshToken";
 import { DfPostUpdateUsecase } from "@/application/usecases/community/DfPostUpdateUsecase";
-import { UserRepository } from "@/domain/repositories/UserRepository";
 import { PrCommunityPostRepository } from "@/infrastructure/repositories/PrCommunityPostRepository";
 import { PrUserRepository } from "@/infrastructure/repositories/PrUserRepository";
 import { cookies } from "next/headers";
@@ -23,7 +22,7 @@ export const PUT = async (
 
     const { title, content, fields } = body;
 
-    const userRepository: UserRepository = new PrUserRepository();
+    const userRepository = new PrUserRepository();
     const verifyRefreshTokenUsecase = new DfVerifyRefreshToken(userRepository);
     const verifiedUser = await verifyRefreshTokenUsecase.execute(refreshToken);
 

--- a/app/user/community/[id]/components/CommunityPostHeader.tsx
+++ b/app/user/community/[id]/components/CommunityPostHeader.tsx
@@ -10,6 +10,9 @@ import {
   CommunityPostTitle,
 } from "./CommunityPostHeader.styled";
 import { formatDate } from "@/utils/date/formatDate";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { ErrorMessage } from "../edit/components/CommunityEdit.styled";
 
 type CommunityPostWithNickname = CommunityPost & {
   userNickname: string;
@@ -19,10 +22,30 @@ interface CommunityPostHeaderProps {
   postDetail: CommunityPostWithNickname;
 }
 const CommunityPostHeader = ({ postDetail }: CommunityPostHeaderProps) => {
+  const [errorMessage, setErrorMessage] = useState("");
+  const router = useRouter();
   const handleDelete = async () => {
     if (confirm("정말 삭제하시겠습니까?")) {
-      console.log("삭제 기능 호출");
-      // API 요청 또는 useCase 실행
+      try {
+        const response = await fetch(`/api/community/${postDetail.id}`, {
+          method: "DELETE",
+        });
+
+        if (!response.ok) {
+          throw new Error("서버 에러 ");
+        }
+
+        const { isDelete } = await response.json();
+        if (isDelete) {
+          alert("게시글 삭제에 성공하였습니다. 커뮤니티로 이동합니다.");
+          router.push("/user/community");
+        }
+      } catch (error: unknown) {
+        if (error instanceof Error) {
+          setErrorMessage(`게시글 삭제 실패: ${error.message}`);
+        }
+        setErrorMessage("게시글 삭제 중 알 수 없는 오류가 발생했습니다.");
+      }
     }
   };
 
@@ -31,22 +54,28 @@ const CommunityPostHeader = ({ postDetail }: CommunityPostHeaderProps) => {
 
   const createdAtFormatted = formatDate(createdAt);
   return (
-    <CommunityPostHeaderSection>
-      <CommunityPostInfo>
-        <CommunityPostTitle>{postDetail.title}</CommunityPostTitle>
+    <>
+      {errorMessage ? (
+        <ErrorMessage>{errorMessage}</ErrorMessage>
+      ) : (
+        <CommunityPostHeaderSection>
+          <CommunityPostInfo>
+            <CommunityPostTitle>{postDetail.title}</CommunityPostTitle>
 
-        <MoreOptionsMenu onDelete={handleDelete} postId={postDetail.id} />
-      </CommunityPostInfo>
-      <div>
-        <p>{postDetail.userNickname}</p>
-        <CommunityPostStats>
-          <CommunityPostCreated>
-            작성일 {createdAtFormatted}
-          </CommunityPostCreated>
-          <CommunityPostview>조회수 {postDetail.view}</CommunityPostview>
-        </CommunityPostStats>
-      </div>
-    </CommunityPostHeaderSection>
+            <MoreOptionsMenu onDelete={handleDelete} postId={postDetail.id} />
+          </CommunityPostInfo>
+          <div>
+            <p>{postDetail.userNickname}</p>
+            <CommunityPostStats>
+              <CommunityPostCreated>
+                작성일 {createdAtFormatted}
+              </CommunityPostCreated>
+              <CommunityPostview>조회수 {postDetail.view}</CommunityPostview>
+            </CommunityPostStats>
+          </div>
+        </CommunityPostHeaderSection>
+      )}
+    </>
   );
 };
 

--- a/application/usecases/community/DfPostDeleteUsecase.ts
+++ b/application/usecases/community/DfPostDeleteUsecase.ts
@@ -1,0 +1,22 @@
+import { CommunityPostRepository } from "@/domain/repositories/CommunityPostRepository";
+import { PostDeleteDto } from "./dto/PostDeleteDto";
+
+export class DfPostDeleteUsecase {
+  constructor(private communityPostRepository: CommunityPostRepository) {}
+
+  async execute(id: string, userId: string): Promise<PostDeleteDto> {
+    try {
+      const isDelete = await this.communityPostRepository.deletePost(
+        id,
+        userId
+      );
+
+      return { isDelete };
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error("게시글 삭제에 실패했습니다.");
+      }
+      throw new Error("게시글 삭제에 실패했습니다.");
+    }
+  }
+}

--- a/application/usecases/community/dto/PostDeleteDto.ts
+++ b/application/usecases/community/dto/PostDeleteDto.ts
@@ -1,0 +1,3 @@
+export interface PostDeleteDto {
+  isDelete: boolean;
+}

--- a/domain/repositories/CommunityPostRepository.ts
+++ b/domain/repositories/CommunityPostRepository.ts
@@ -62,4 +62,6 @@ export interface CommunityPostRepository {
     content: string,
     selectedFields: string[]
   ): Promise<number>;
+
+  deletePost(id: string, userId: string): Promise<boolean>;
 }

--- a/infrastructure/repositories/PrCommunityPostRepository.ts
+++ b/infrastructure/repositories/PrCommunityPostRepository.ts
@@ -240,4 +240,19 @@ export class PrCommunityPostRepository implements CommunityPostRepository {
       throw new Error("게시글 수정 중 오류가 발생했습니다.");
     }
   }
+
+  async deletePost(id: string, userId: string): Promise<boolean> {
+    const postId = Number(id);
+    try {
+      const result = await prisma.communityPost.deleteMany({
+        where: {
+          id: postId,
+          userId: userId,
+        },
+      });
+      return result.count > 0;
+    } catch {
+      throw new Error("게시글 삭제 중 오류가 발생했습니다.");
+    }
+  }
 }


### PR DESCRIPTION
## 🔘Part

- [x] FE

  <br/>

## 🔎 작업 내용
- 커뮤니티 게시글 삭제 기능 구현
- 해당 userId를 검사하여 해당 게시글 userId랑 postId맞다면 삭제 구현 
- 삭제 완성 후 커뮤니티 페이지로 이동
  <br/>

## 이미지 첨부

https://github.com/user-attachments/assets/400ce2e1-fd2e-4016-8d50-7e4a380c6ff3


<br/>

## 🔧 앞으로의 과제
- 커뮤니티 좋아요 기능 구현

  <br/>

## ➕ 이슈 링크

- [fungle #33 ]

<br/>
