### PR TITLE
[feat] 커뮤니티 게시글 좋아요 기능 구현  #36

### DIFF
--- a/app/api/community/like/route.ts
+++ b/app/api/community/like/route.ts
@@ -1,0 +1,45 @@
+import { DfVerifyRefreshToken } from "@/application/usecases/auth/DfVerifyRefreshToken";
+import { DfTogglePostLikeUsecase } from "@/application/usecases/community/DfTogglePostLikeUsecase";
+import { PrCommunityPostLikeRepository } from "@/infrastructure/repositories/PrCommunityPostLikeRepository";
+import { PrUserRepository } from "@/infrastructure/repositories/PrUserRepository";
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+
+export const POST = async (request: NextRequest) => {
+  try {
+    const body = await request.json();
+    const { postId: id } = await body;
+
+    const cookieStore = await cookies();
+    const refreshToken = cookieStore.get("refreshToken")?.value;
+
+    if (!refreshToken) {
+      return NextResponse.json({ error: "No refresh token" }, { status: 401 });
+    }
+    const userRepository = new PrUserRepository();
+    const verifyRefreshTokenUsecase = new DfVerifyRefreshToken(userRepository);
+    const verifiedUser = await verifyRefreshTokenUsecase.execute(refreshToken);
+
+    if (!verifiedUser) {
+      return NextResponse.json(
+        { error: "유효하지 않은 사용자" },
+        { status: 401 }
+      );
+    }
+
+    const { id: userId } = verifiedUser;
+
+    const communityPostLikeRepository = new PrCommunityPostLikeRepository();
+    const postLikeUsecase = new DfTogglePostLikeUsecase(
+      communityPostLikeRepository
+    );
+    const likeCount = await postLikeUsecase.execute(id, userId);
+
+    return NextResponse.json(likeCount);
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json({ error: "Route error" }, { status: 500 });
+  }
+};

--- a/app/api/community/like/route.ts
+++ b/app/api/community/like/route.ts
@@ -33,9 +33,9 @@ export const POST = async (request: NextRequest) => {
     const postLikeUsecase = new DfTogglePostLikeUsecase(
       communityPostLikeRepository
     );
-    const likeCount = await postLikeUsecase.execute(id, userId);
+    const result = await postLikeUsecase.execute(id, userId);
 
-    return NextResponse.json(likeCount);
+    return NextResponse.json(result, { status: 200 });
   } catch (error: unknown) {
     if (error instanceof Error) {
       return NextResponse.json({ error: error.message }, { status: 500 });

--- a/app/user/community/[id]/components/CommunityPostContent.tsx
+++ b/app/user/community/[id]/components/CommunityPostContent.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { CommunityPost } from "@prisma/client";
 import {
   CommunityPostContentSection,
@@ -5,6 +6,7 @@ import {
   CommunityLikeButton,
 } from "./CommunityPostContent.styled";
 import Image from "next/image";
+import { useState } from "react";
 
 type CommunityPostWithNicknameAndLikes = CommunityPost & {
   userNickname: string;
@@ -16,6 +18,31 @@ interface CommunityPostHeaderProps {
 }
 
 const CommunityPostContent = ({ postDetail }: CommunityPostHeaderProps) => {
+  const [likes, setLikes] = useState(postDetail.likes);
+  const handleLike = async () => {
+    try {
+      const response = await fetch("/api/community/like", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ postId: postDetail.id }),
+      });
+
+      if (!response.ok) {
+        throw new Error("서버 에러");
+      }
+
+      const { likeCount } = await response.json();
+
+      setLikes(likeCount);
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        alert(`좋아요 처리 중 오류 발생: ${error.message}`);
+      } else {
+        alert("좋아요 처리 중 알 수 없는 오류가 발생했습니다.");
+      }
+    }
+  };
+
   if (!postDetail) {
     return <main>게시글을 찾을 수 없습니다.</main>;
   }
@@ -23,14 +50,14 @@ const CommunityPostContent = ({ postDetail }: CommunityPostHeaderProps) => {
     <CommunityPostContentSection>
       <div style={{ whiteSpace: "pre-wrap" }}>{postDetail.content}</div>
       <CommunityPostLikeButtonBox>
-        <CommunityLikeButton>
+        <CommunityLikeButton onClick={handleLike}>
           <Image
             src="/icon/heart.svg"
             alt="좋아요 버튼"
             width={20}
             height={20}
           />
-          {postDetail.likes}
+          {likes}
         </CommunityLikeButton>
       </CommunityPostLikeButtonBox>
     </CommunityPostContentSection>

--- a/application/usecases/community/DfPostDetailUsecase.ts
+++ b/application/usecases/community/DfPostDetailUsecase.ts
@@ -28,6 +28,7 @@ export class DfPostDetailUsecase {
         view: post.view,
         userNickname: user?.nickname,
         likes: post._count?.communityPostLikes || 0,
+        likedUserId: post.communityPostLikes.map((like) => like.userId),
       };
 
       return postDetail;

--- a/application/usecases/community/DfTogglePostLikeUsecase.ts
+++ b/application/usecases/community/DfTogglePostLikeUsecase.ts
@@ -1,0 +1,25 @@
+import { CommunityPostLikeRepository } from "@/domain/repositories/CommunityPostLikeRepository";
+import { ToggleLikeDto } from "./dto/ToggleLikeDto";
+
+export class DfTogglePostLikeUsecase {
+  constructor(
+    private communityPostLikeRepository: CommunityPostLikeRepository
+  ) {}
+
+  async execute(id: string, userId: string): Promise<ToggleLikeDto> {
+    try {
+      const likeCount = await this.communityPostLikeRepository.toggleLike(
+        id,
+        userId
+      );
+
+      return { likeCount };
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        throw new Error(`게시글 좋아요 에러(infrastructure) : {error.message}`);
+      }
+
+      return { likeCount: 0 };
+    }
+  }
+}

--- a/application/usecases/community/DfTogglePostLikeUsecase.ts
+++ b/application/usecases/community/DfTogglePostLikeUsecase.ts
@@ -8,18 +8,17 @@ export class DfTogglePostLikeUsecase {
 
   async execute(id: string, userId: string): Promise<ToggleLikeDto> {
     try {
-      const likeCount = await this.communityPostLikeRepository.toggleLike(
+      const result = await this.communityPostLikeRepository.toggleLike(
         id,
         userId
       );
 
-      return { likeCount };
+      return result;
     } catch (error: unknown) {
       if (error instanceof Error) {
-        throw new Error(`게시글 좋아요 에러(infrastructure) : {error.message}`);
+        throw new Error(`게시글 좋아요 에러(infrastructure): ${error.message}`);
       }
-
-      return { likeCount: 0 };
+      throw new Error("게시글 좋아요 에러");
     }
   }
 }

--- a/application/usecases/community/dto/CommunityPostWithNicknameAndLikesDto.ts
+++ b/application/usecases/community/dto/CommunityPostWithNicknameAndLikesDto.ts
@@ -3,4 +3,5 @@ import { CommunityPost } from "@prisma/client";
 export interface PostWithLikesAndUserNicknameDto extends CommunityPost {
   userNickname?: string;
   likes?: number;
+  likedUserId?: string[];
 }

--- a/application/usecases/community/dto/ToggleLikeDto.ts
+++ b/application/usecases/community/dto/ToggleLikeDto.ts
@@ -1,3 +1,4 @@
 export interface ToggleLikeDto {
   likeCount: number;
+  isLiked: boolean;
 }

--- a/application/usecases/community/dto/ToggleLikeDto.ts
+++ b/application/usecases/community/dto/ToggleLikeDto.ts
@@ -1,0 +1,3 @@
+export interface ToggleLikeDto {
+  likeCount: number;
+}

--- a/domain/repositories/CommunityPostLikeRepository.ts
+++ b/domain/repositories/CommunityPostLikeRepository.ts
@@ -1,3 +1,6 @@
 export interface CommunityPostLikeRepository {
-  toggleLike(id: string, userId: string): Promise<number>;
+  toggleLike(
+    id: string,
+    userId: string
+  ): Promise<{ likeCount: number; isLiked: boolean }>;
 }

--- a/domain/repositories/CommunityPostLikeRepository.ts
+++ b/domain/repositories/CommunityPostLikeRepository.ts
@@ -1,1 +1,3 @@
-// commit test
+export interface CommunityPostLikeRepository {
+  toggleLike(id: string, userId: string): Promise<number>;
+}

--- a/domain/repositories/CommunityPostRepository.ts
+++ b/domain/repositories/CommunityPostRepository.ts
@@ -12,6 +12,11 @@ export type PostWithRelations = Prisma.CommunityPostGetPayload<{
 
 export type PostWithPostLikes = Prisma.CommunityPostGetPayload<{
   include: {
+    communityPostLikes: {
+      select: {
+        userId: true;
+      };
+    };
     _count: {
       select: {
         communityPostLikes: true;

--- a/infrastructure/repositories/PrCommunityPostLikeRepository.ts
+++ b/infrastructure/repositories/PrCommunityPostLikeRepository.ts
@@ -4,7 +4,10 @@ import { prisma } from "../config/prisma";
 export class PrCommunityPostLikeRepository
   implements CommunityPostLikeRepository
 {
-  async toggleLike(id: string, userId: string): Promise<number> {
+  async toggleLike(
+    id: string,
+    userId: string
+  ): Promise<{ likeCount: number; isLiked: boolean }> {
     const postId = Number(id);
     try {
       const existingLike = await prisma.communityPostLike.findUnique({
@@ -12,13 +15,14 @@ export class PrCommunityPostLikeRepository
           userId_postId: { userId, postId },
         },
       });
-
+      let isLiked: boolean;
       if (existingLike) {
         await prisma.communityPostLike.delete({
           where: {
             userId_postId: { userId, postId },
           },
         });
+        isLiked = false;
       } else {
         await prisma.communityPostLike.create({
           data: {
@@ -26,6 +30,7 @@ export class PrCommunityPostLikeRepository
             postId,
           },
         });
+        isLiked = true;
       }
 
       const likeCount = await prisma.communityPostLike.count({
@@ -34,7 +39,7 @@ export class PrCommunityPostLikeRepository
         },
       });
 
-      return likeCount;
+      return { likeCount, isLiked };
     } catch {
       throw new Error("좋아요를 불러오는 중 오류가 발생했습니다.");
     }

--- a/infrastructure/repositories/PrCommunityPostLikeRepository.ts
+++ b/infrastructure/repositories/PrCommunityPostLikeRepository.ts
@@ -1,1 +1,42 @@
-// commit test
+import { CommunityPostLikeRepository } from "@/domain/repositories/CommunityPostLikeRepository";
+import { prisma } from "../config/prisma";
+
+export class PrCommunityPostLikeRepository
+  implements CommunityPostLikeRepository
+{
+  async toggleLike(id: string, userId: string): Promise<number> {
+    const postId = Number(id);
+    try {
+      const existingLike = await prisma.communityPostLike.findUnique({
+        where: {
+          userId_postId: { userId, postId },
+        },
+      });
+
+      if (existingLike) {
+        await prisma.communityPostLike.delete({
+          where: {
+            userId_postId: { userId, postId },
+          },
+        });
+      } else {
+        await prisma.communityPostLike.create({
+          data: {
+            userId,
+            postId,
+          },
+        });
+      }
+
+      const likeCount = await prisma.communityPostLike.count({
+        where: {
+          postId,
+        },
+      });
+
+      return likeCount;
+    } catch {
+      throw new Error("좋아요를 불러오는 중 오류가 발생했습니다.");
+    }
+  }
+}

--- a/infrastructure/repositories/PrCommunityPostRepository.ts
+++ b/infrastructure/repositories/PrCommunityPostRepository.ts
@@ -149,6 +149,11 @@ export class PrCommunityPostRepository implements CommunityPostRepository {
       const post = await prisma.communityPost.findUnique({
         where: { id: postId },
         include: {
+          communityPostLikes: {
+            select: {
+              userId: true,
+            },
+          },
           _count: {
             select: {
               communityPostLikes: true,


### PR DESCRIPTION
## 🔘Part

- [x] FE

  <br/>

## 🔎 작업 내용
- 커뮤니티 게시글 좋아요 클릭 시 토글 방식으로 기능을 구현
- 커뮤니티 게시글 좋아요 클릭 시 DB에 사용자가 있다면 -1, 없다면 +1
  <br/>

## 이미지 첨부

https://github.com/user-attachments/assets/0ffa951a-e53b-4bd4-91c9-f91d3bcb2a6b


<br/>

## 🔧 앞으로의 과제

- 내가 좋아요 누르면 하트가 채워지기 수정
  <br/>

## ➕ 이슈 링크

- [fungle #36 ]

<br/>
