### PR TITLE
[feat] 커뮤니티 댓글 수정 기능 구현 #28

### DIFF
--- a/app/api/community/comment/[id]/route.ts
+++ b/app/api/community/comment/[id]/route.ts
@@ -1,6 +1,7 @@
 import { DfVerifyRefreshToken } from "@/application/usecases/auth/DfVerifyRefreshToken";
 import { DfCommentCountUsecase } from "@/application/usecases/comment/DfCommentCountUsecase";
 import { DfCommentCreateUsecase } from "@/application/usecases/comment/DfCommentCreateUsecase";
+import { DfCommentUpdateUsecase } from "@/application/usecases/comment/DfCommentUpdateUsecase";
 import { UserRepository } from "@/domain/repositories/UserRepository";
 import { PrCommunityCommentRepository } from "@/infrastructure/repositories/PrCommunityCommentRepository";
 import { PrUserRepository } from "@/infrastructure/repositories/PrUserRepository";
@@ -11,7 +12,7 @@ export const GET = async (
   request: NextRequest,
   { params }: { params: { id: string } }
 ) => {
-  const { id: postId } = params;
+  const { id: postId } = await params;
 
   try {
     const communityCommentRepository = new PrCommunityCommentRepository();
@@ -37,7 +38,7 @@ export const POST = async (
   request: NextRequest,
   { params }: { params: { id: string } }
 ) => {
-  const { id } = params;
+  const { id } = await params;
   const body = await request.json();
   const { comment } = body;
 
@@ -64,6 +65,51 @@ export const POST = async (
       communityCommentRepository
     );
     const result = await commentCreatetUsecase.execute(id, userId, comment);
+
+    return NextResponse.json({ result });
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json(
+      { error: "Route : postId가 없습니다." },
+      { status: 500 }
+    );
+  }
+};
+
+export const PATCH = async (
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) => {
+  const { id } = await params;
+  const body = await request.json();
+  const { comment } = body;
+
+  try {
+    const cookieStore = await cookies();
+    const refreshToken = cookieStore.get("refreshToken")?.value;
+
+    if (!refreshToken) {
+      return NextResponse.json({ error: "No refresh token" }, { status: 401 });
+    }
+
+    const userRepository: UserRepository = new PrUserRepository();
+    const verifyRefreshTokenUsecase = new DfVerifyRefreshToken(userRepository);
+    const verifiedUser = await verifyRefreshTokenUsecase.execute(refreshToken);
+
+    if (!verifiedUser) {
+      return NextResponse.json({ user: null }, { status: 401 });
+    }
+
+    const { id: userId } = verifiedUser;
+
+    const communityCommentRepository = new PrCommunityCommentRepository();
+    const commentUpdateUsecase = new DfCommentUpdateUsecase(
+      communityCommentRepository
+    );
+
+    const result = await commentUpdateUsecase.execute(id, userId, comment);
 
     return NextResponse.json({ result });
   } catch (error: unknown) {

--- a/app/user/community/[id]/components/CommunityPostHeader.tsx
+++ b/app/user/community/[id]/components/CommunityPostHeader.tsx
@@ -13,6 +13,7 @@ import { formatDate } from "@/utils/date/formatDate";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { ErrorMessage } from "../edit/components/CommunityEdit.styled";
+import useAuthStore from "@/store/useAuthStore";
 
 type CommunityPostWithNickname = CommunityPost & {
   userNickname: string;
@@ -24,6 +25,8 @@ interface CommunityPostHeaderProps {
 const CommunityPostHeader = ({ postDetail }: CommunityPostHeaderProps) => {
   const [errorMessage, setErrorMessage] = useState("");
   const router = useRouter();
+  const { user } = useAuthStore();
+  const userId = user?.id;
   const handleDelete = async () => {
     if (confirm("정말 삭제하시겠습니까?")) {
       try {
@@ -61,8 +64,13 @@ const CommunityPostHeader = ({ postDetail }: CommunityPostHeaderProps) => {
         <CommunityPostHeaderSection>
           <CommunityPostInfo>
             <CommunityPostTitle>{postDetail.title}</CommunityPostTitle>
-
-            <MoreOptionsMenu onDelete={handleDelete} postId={postDetail.id} />
+            {userId === postDetail.userId && (
+              <MoreOptionsMenu
+                mode="post"
+                onDelete={handleDelete}
+                postId={postDetail.id}
+              />
+            )}
           </CommunityPostInfo>
           <div>
             <p>{postDetail.userNickname}</p>

--- a/app/user/community/components/CommunityCommentEdit.styled.tsx
+++ b/app/user/community/components/CommunityCommentEdit.styled.tsx
@@ -1,0 +1,7 @@
+import styled from "styled-components";
+
+export const CommentButtonBox = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.625rem;
+`;

--- a/app/user/community/components/CommunityCommentEdit.tsx
+++ b/app/user/community/components/CommunityCommentEdit.tsx
@@ -1,0 +1,78 @@
+"use client";
+import Button from "@/components/button/Button";
+import Textarea from "@/components/textarea/Textarea";
+import { CommentButtonBox } from "./CommunityCommentEdit.styled";
+import { useState } from "react";
+
+const CommunityCommentEdit = ({
+  setTrigger,
+  commentContent,
+  commentId,
+  onCancel,
+}: {
+  setTrigger: React.Dispatch<React.SetStateAction<boolean>>;
+  commentContent: string;
+  commentId: number;
+  onCancel: () => void;
+}) => {
+  const [editComment, setEditComment] = useState<string>(commentContent);
+  const [errorMessage, setErrorMessage] = useState<string>("");
+
+  const handleEditComment = async () => {
+    if (editComment === commentContent) {
+      return alert("수정된 내용이 없습니다.");
+    } else if (editComment.trim() === "") {
+      return alert("내용을 입력해주세요.");
+    }
+
+    try {
+      const response = await fetch(`/api/community/comment/${commentId}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ comment: editComment }),
+      });
+
+      if (!response.ok) {
+        throw new Error("댓글 수정에 실패했습니다.");
+      }
+
+      const result = await response.json();
+      if (result.result === true) {
+        onCancel();
+        setTrigger((prev) => !prev);
+      }
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        setErrorMessage(error.message);
+      }
+    }
+  };
+
+  return (
+    <>
+      {errorMessage && <div style={{ color: "red" }}>{errorMessage}</div>}
+      <Textarea
+        ariaLabel="댓글 수정"
+        height="15vh"
+        defaultValue={commentContent}
+        onChange={(e) => setEditComment(e.target.value)}
+      />
+      <CommentButtonBox>
+        <Button buttonSize="small" backgroudColor="white" onClick={onCancel}>
+          취소
+        </Button>
+        <Button
+          buttonSize="small"
+          backgroudColor="success"
+          onClick={handleEditComment}
+        >
+          수정
+        </Button>
+      </CommentButtonBox>
+    </>
+  );
+};
+
+export default CommunityCommentEdit;

--- a/app/user/community/components/MoreOptionMenu.tsx
+++ b/app/user/community/components/MoreOptionMenu.tsx
@@ -13,11 +13,20 @@ import {
 import Link from "next/link";
 
 interface MoreOptionsMenuProps {
-  onDelete: () => void;
+  mode: "post" | "comment";
+  onDelete?: () => void;
+  onEdit?: () => void;
   postId?: number;
+  isOwner?: boolean;
 }
 
-const MoreOptionsMenu = ({ onDelete, postId }: MoreOptionsMenuProps) => {
+const MoreOptionsMenu = ({
+  mode = "post",
+  onDelete,
+  onEdit,
+  postId,
+  isOwner,
+}: MoreOptionsMenuProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
@@ -45,6 +54,7 @@ const MoreOptionsMenu = ({ onDelete, postId }: MoreOptionsMenuProps) => {
       document.removeEventListener("mousedown", handleClickOutside);
     };
   }, [isOpen]);
+
   return (
     <Wrapper ref={menuRef}>
       <MoreButton onClick={handleToggleMenu}>
@@ -57,8 +67,21 @@ const MoreOptionsMenu = ({ onDelete, postId }: MoreOptionsMenuProps) => {
       </MoreButton>
       {isOpen && (
         <Dropdown>
-          <Link href={`/user/community/${postId}/edit/`}>
-            <EditBox>
+          {mode === "post" && (
+            <Link href={`/user/community/${postId}/edit/`}>
+              <EditBox>
+                <Image
+                  src="/icon/edit_pen.svg"
+                  alt="수정"
+                  width={20}
+                  height={20}
+                />
+                수정
+              </EditBox>
+            </Link>
+          )}
+          {mode === "comment" && onEdit && isOwner && (
+            <EditBox onClick={onEdit}>
               <Image
                 src="/icon/edit_pen.svg"
                 alt="수정"
@@ -67,7 +90,8 @@ const MoreOptionsMenu = ({ onDelete, postId }: MoreOptionsMenuProps) => {
               />
               수정
             </EditBox>
-          </Link>
+          )}
+
           <MenuItem onClick={onDelete}>
             <Image src="/icon/delete.svg" alt="삭제" width={20} height={20} />
             삭제

--- a/application/usecases/comment/DfCommentUpdateUsecase.ts
+++ b/application/usecases/comment/DfCommentUpdateUsecase.ts
@@ -1,0 +1,23 @@
+import { CommunityCommentRepository } from "@/domain/repositories/CommunityCommentRepository";
+
+export class DfCommentUpdateUsecase {
+  constructor(private commentRepository: CommunityCommentRepository) {}
+
+  async execute(id: string, userId: string, content: string) {
+    try {
+      const result = await this.commentRepository.commentUpdate(
+        id,
+        userId,
+        content
+      );
+
+      return result;
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        throw new Error(error.message);
+      } else {
+        throw new Error("[DfCommentUpdateUsecase] 알 수 없는 오류 발생");
+      }
+    }
+  }
+}

--- a/components/comment/CommentHeader.tsx
+++ b/components/comment/CommentHeader.tsx
@@ -52,7 +52,7 @@ const CommentHeader = ({ postId }: { postId: string }) => {
         />
       </TextareaWrapper>
 
-      <Comment postId={postId} trigger={trigger} />
+      <Comment postId={postId} trigger={trigger} setTrigger={setTrigger} />
     </CommentSection>
   );
 };

--- a/domain/repositories/CommunityCommentRepository.ts
+++ b/domain/repositories/CommunityCommentRepository.ts
@@ -21,4 +21,5 @@ export interface CommunityCommentRepository {
   findAll(postId: string): Promise<CommentWithRelations[]>;
   commentCount(postId: string): Promise<number>;
   create(id: string, userId: string, comment: string): Promise<boolean>;
+  commentUpdate(id: string, userId: string, content: string): Promise<boolean>;
 }

--- a/infrastructure/repositories/PrCommunityCommentRepository.ts
+++ b/infrastructure/repositories/PrCommunityCommentRepository.ts
@@ -65,4 +65,38 @@ export class PrCommunityCommentRepository
       throw new Error("infra : 댓글을 작성하는 데 실패했습니다.");
     }
   }
+
+  async commentUpdate(
+    id: string,
+    userId: string,
+    content: string
+  ): Promise<boolean> {
+    const commentId = Number(id);
+    try {
+      const existingComment = await prisma.communityComment.findUnique({
+        where: { id: commentId },
+      });
+
+      if (!existingComment) {
+        throw new Error("댓글을 찾을 수 없습니다.");
+      }
+
+      if (existingComment.userId !== userId) {
+        throw new Error("댓글 작성자만 수정할 수 있습니다.");
+      }
+
+      await prisma.communityComment.update({
+        where: { id: commentId },
+        data: { comment: content },
+      });
+
+      return true;
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        throw new Error(error.message);
+      } else {
+        throw new Error("infra: 알 수 없는 오류가 발생했습니다.");
+      }
+    }
+  }
 }


### PR DESCRIPTION
## 🔘Part

- [x] FE

  <br/>

## 🔎 작업 내용
- 커뮤니티 댓글 수정 기능 구현
- 로그인한 사용자와 댓글 사용자가 일치할 경우 `MoreOptionsMenu` 표시
- 댓글 수정 전 내용 수정 후 내용 비교하여 수정된 내용 없으면 return
- 빈 문자열 수정도 return
  <br/>

## 이미지 첨부

https://github.com/user-attachments/assets/b77663b8-aa36-4166-a4e6-4b84431ef53c





<br/>

## 🔧 앞으로의 과제






  <br/>

## ➕ 이슈 링크

- [fungle #28 ]

<br/>
