### PR TITLE
[design, feat] 요일별 연재 이미지 크기 조정, 오늘 요일로 랜더링

### DIFF
--- a/app/user/novel/component/SerialDayBook.styled.tsx
+++ b/app/user/novel/component/SerialDayBook.styled.tsx
@@ -62,8 +62,9 @@ export const Thumbnail = styled.div`
 
 export const StyledImage = styled(Image)`
   width: 100%;  
-  height: 100%; 
-  object-fit: cover;  
+  object-fit: cover;
+  min-height: 14.25rem;
+
 `;
 
 export const Content = styled.div`

--- a/app/user/novel/component/SerialDayBook.tsx
+++ b/app/user/novel/component/SerialDayBook.tsx
@@ -9,11 +9,6 @@ import {
 import ProgressBar from "@/components/progressbar/ProgressBar";
 import { SerialDayNovelDto } from "@/application/usecases/novel/dto/SerialDayNovel";
 
-interface DaysProps {
-  selectedDay: string;
-  setSelectedDay: (value: string) => void;
-}
-
 const dayMapping: { [key: string]: string } = {
   "월": "monday",
   "화": "tuesday",
@@ -24,8 +19,14 @@ const dayMapping: { [key: string]: string } = {
   "일": "sunday",
 };
 
-const SerialDayBook = ({ selectedDay, setSelectedDay }: DaysProps) => {
-  const router = useRouter(); 
+const getTodayKoreanDay = (): string => {
+  const days = ["일", "월", "화", "수", "목", "금", "토"];
+  return days[new Date().getDay()];
+};
+
+const SerialDayBook = () => {
+  const router = useRouter();
+  const [selectedDay, setSelectedDay] = useState<string>(getTodayKoreanDay()); 
   const [books, setBooks] = useState<SerialDayNovelDto[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
 
@@ -49,7 +50,7 @@ const SerialDayBook = ({ selectedDay, setSelectedDay }: DaysProps) => {
     };
 
     fetchNovelsByDay();
-  }, [selectedDay]); 
+  }, [selectedDay]);
 
   return (
     <>
@@ -73,7 +74,6 @@ const SerialDayBook = ({ selectedDay, setSelectedDay }: DaysProps) => {
                   alt="소설 썸네일"
                   width={120} 
                   height={160} 
-                  
                 />
               </Thumbnail>
               <Content>


### PR DESCRIPTION
## 🔘Part

- [x] FE

  <br/>

## 🔎 작업 내용

  <br/>

## 이미지 첨부

<br/>

## 🔧 앞으로의 과제


  <br/>

## ➕ 이슈 링크

- [fungle #280 ]

<br/>
