### PR TITLE
[feat] userId로 게시글, 소설 가져오는 BE 구현 및 api 연결 #287

### DIFF
--- a/app/api/user/count/route.ts
+++ b/app/api/user/count/route.ts
@@ -1,0 +1,37 @@
+import { DfGetUserStatsUsecase } from "@/application/usecases/user/DfGetUserStatsUsecase";
+import { userDi } from "@/infrastructure/config/userDi";
+import { PrCommunityPostRepository } from "@/infrastructure/repositories/PrCommunityPostRepository";
+import { PrNovelRepository } from "@/infrastructure/repositories/PrNovelRepostiory";
+import { NextResponse } from "next/server";
+
+export const GET = async () => {
+  const userId = await userDi.getUserIdUsecase.execute();
+
+  if (!userId) {
+    return NextResponse.json(
+      { error: "로그인 되어 있지 않습니다." },
+      { status: 401 }
+    );
+  }
+
+  try {
+    const novelRepository = new PrNovelRepository();
+    const communityPostRepository = new PrCommunityPostRepository();
+
+    const getUserStatsUsecase = new DfGetUserStatsUsecase(
+      novelRepository,
+      communityPostRepository
+    );
+
+    const counts = await getUserStatsUsecase.execute(userId);
+
+    return NextResponse.json({ counts }, { status: 200 });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: "사용자가 작성한 글 개수를 가져오는 데 실패했습니다.",
+      },
+      { status: 500 }
+    );
+  }
+};

--- a/app/user/components/ProfileInfo.tsx
+++ b/app/user/components/ProfileInfo.tsx
@@ -1,17 +1,45 @@
+import { useEffect, useState } from "react";
 import { InfoBox, InfoSection } from "./ProfileInfo.styled";
+import { UserStatsDto } from "@/application/usecases/user/dto/UserStats";
 
 const ProfileInfo = () => {
+  const [postCount, setPostCount] = useState<number>(0);
+  const [novelCount, setNovelCount] = useState<number>(0);
+
+  useEffect(() => {
+    const fetchCount = async () => {
+      try {
+        const response = await fetch("/api/user/count");
+
+        const data = await response.json();
+
+        if (!response.ok) throw new Error(data.error);
+
+        const counts: UserStatsDto = data.counts;
+
+        setPostCount(counts.postCount ?? 0);
+        setNovelCount(counts.novelCount ?? 0);
+      } catch (error: unknown) {
+        if (error instanceof Error) {
+          throw new Error("데이터를 불러오는 중 오류가 발생했습니다.");
+        }
+      }
+    };
+
+    fetchCount();
+  }, []);
+
   return (
     <InfoSection>
-      {/* 백엔드 연결 후 각 count로 변경 */}
       <InfoBox>
         <h5>내가 쓴 글</h5>
-        <p>12</p>
+        <p>{postCount}</p>
       </InfoBox>
       <InfoBox>
         <h5>내가 쓴 소설</h5>
-        <p>2</p>
+        <p>{novelCount}</p>
       </InfoBox>
+      {/* 펀딩 금액 가져오는 BE 구현 예정 */}
       <InfoBox>
         <h5>펀딩 금액</h5>
         <p>1,000,000</p>

--- a/application/usecases/user/DfGetUserStatsUsecase.ts
+++ b/application/usecases/user/DfGetUserStatsUsecase.ts
@@ -1,0 +1,22 @@
+import { CommunityPostRepository } from "@/domain/repositories/CommunityPostRepository";
+import { NovelRepository } from "@/domain/repositories/NovelRepository";
+import { UserStatsDto } from "./dto/UserStats";
+
+export class DfGetUserStatsUsecase {
+  constructor(
+    private readonly novelRepository: NovelRepository,
+    private readonly communityPostRepository: CommunityPostRepository
+  ) {}
+
+  async execute(userId: string): Promise<UserStatsDto> {
+    const novelCount = await this.novelRepository.getNovelCountByUserId(userId);
+    const postCount = await this.communityPostRepository.getPostCountByUserId(
+      userId
+    );
+
+    return {
+      novelCount,
+      postCount,
+    };
+  }
+}

--- a/application/usecases/user/dto/UserStats.ts
+++ b/application/usecases/user/dto/UserStats.ts
@@ -1,0 +1,4 @@
+export interface UserStatsDto {
+  novelCount: number;
+  postCount: number;
+}

--- a/domain/repositories/CommunityPostRepository.ts
+++ b/domain/repositories/CommunityPostRepository.ts
@@ -71,4 +71,5 @@ export interface CommunityPostRepository {
   deletePost(id: string, userId: string): Promise<boolean>;
   getPostByUserId(userId: string): Promise<PostWithRelations[]>;
   updatePostStatus(userId: string, postId: number): Promise<void>;
+  getPostCountByUserId(userId: string): Promise<number>;
 }

--- a/domain/repositories/NovelRepository.ts
+++ b/domain/repositories/NovelRepository.ts
@@ -21,4 +21,5 @@ export interface NovelRepository {
   deleteNovelById(novelId: number): Promise<boolean>;
   updateNovelSerialStatus(novelId: number, status: string): Promise<boolean>;
   getAllNovels(): Promise<Novel[]>;
+  getNovelCountByUserId(userId: string): Promise<number>;
 }

--- a/infrastructure/repositories/PrCommunityPostRepository.ts
+++ b/infrastructure/repositories/PrCommunityPostRepository.ts
@@ -315,4 +315,8 @@ export class PrCommunityPostRepository implements CommunityPostRepository {
       throw new Error("게시글 모집 상태 변경에 실패했습니다.");
     }
   }
+
+  async getPostCountByUserId(userId: string): Promise<number> {
+    return await prisma.communityPost.count({ where: { userId: userId } });
+  }
 }

--- a/infrastructure/repositories/PrNovelRepostiory.ts
+++ b/infrastructure/repositories/PrNovelRepostiory.ts
@@ -100,4 +100,10 @@ export class PrNovelRepository implements NovelRepository {
   async getAllNovels(): Promise<Novel[]> {
     return await prisma.novel.findMany();
   }
+
+  async getNovelCountByUserId(userId: string): Promise<number> {
+    return await prisma.novel.count({
+      where: { userId: userId },
+    });
+  }
 }


### PR DESCRIPTION
## 🔘Part

- [x] BE

  <br/>

## 🔎 작업 내용
- 소설 개수 가져오는 repository 구현
- 게시글 개수 가져오는 repository 구현
- 소설, 게시글 개수 가져오는 api 구현 및 연결
  <br/>

## 이미지 첨부
<img width="404" alt="image" src="https://github.com/user-attachments/assets/c5b0bb39-56aa-4da9-8490-e8118bc63df7" />

<br/>

## 🔧 앞으로의 과제
- 로그아웃 기능 구현
- 탈퇴 기능 구현

  <br/>

## ➕ 이슈 링크

- [fungle #287 ]

<br/>
