### PR TITLE
[feat] 로그아웃 기능 구현 #291

### DIFF
--- a/app/api/logout/route.ts
+++ b/app/api/logout/route.ts
@@ -1,0 +1,27 @@
+import { DfLogoutUsecase } from "@/application/usecases/auth/DfLogoutUsecase";
+import { AuthRepository } from "@/domain/repositories/AuthRepository";
+import { PrAuthRepository } from "@/infrastructure/repositories/PrAuthRepository";
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+export const POST = async () => {
+  const cookieStore = await cookies();
+  const refreshToken = cookieStore.get("refreshToken")?.value;
+
+  const authRepository: AuthRepository = new PrAuthRepository();
+  const logoutUsecase = new DfLogoutUsecase(authRepository);
+
+  if (refreshToken) {
+    await logoutUsecase.execute(refreshToken);
+  }
+
+  const response = NextResponse.json(
+    { message: "성공적으로 로그아웃 되었습니다." },
+    { status: 200 }
+  );
+
+  cookieStore.set("accessToken", "", { maxAge: 0, path: "/" });
+  cookieStore.set("refreshToken", "", { maxAge: 0, path: "/" });
+
+  return response;
+};

--- a/application/usecases/auth/DfLogoutUsecase.ts
+++ b/application/usecases/auth/DfLogoutUsecase.ts
@@ -1,0 +1,9 @@
+import { AuthRepository } from "@/domain/repositories/AuthRepository";
+
+export class DfLogoutUsecase {
+  constructor(private authRepository: AuthRepository) {}
+
+  async execute(refreshToken: string) {
+    await this.authRepository.deleteRefreshToken(refreshToken);
+  }
+}

--- a/components/header/Header.tsx
+++ b/components/header/Header.tsx
@@ -34,7 +34,8 @@ const Header = () => {
     }
   };
 
-  const handleLogout = () => {
+  const handleLogout = async () => {
+    await fetch("/api/logout", { method: "POST" });
     setIsLoggedIn(false);
     router.push("/");
   };

--- a/domain/repositories/AuthRepository.ts
+++ b/domain/repositories/AuthRepository.ts
@@ -4,4 +4,5 @@ export interface AuthRepository {
   ): Promise<{ accessToken: string; refreshToken: string }>;
   findRefreshTokenByUserId(userId: string): Promise<string | null>;
   updateRefreshToken(userId: string, newRefreshToken: string): Promise<void>;
+  deleteRefreshToken(refreshToken: string): Promise<void>;
 }

--- a/infrastructure/repositories/PrAuthRepository.ts
+++ b/infrastructure/repositories/PrAuthRepository.ts
@@ -41,4 +41,8 @@ export class PrAuthRepository implements AuthRepository {
       data: { token: newRefreshToken },
     });
   }
+
+  async deleteRefreshToken(refreshToken: string): Promise<void> {
+    await prisma.refreshToken.deleteMany({ where: { token: refreshToken } });
+  }
 }

--- a/infrastructure/repositories/PrNovelRepostiory.ts
+++ b/infrastructure/repositories/PrNovelRepostiory.ts
@@ -3,7 +3,6 @@ import { NovelRepository } from "@/domain/repositories/NovelRepository";
 import { Novel, Prisma } from "@prisma/client";
 
 export class PrNovelRepository implements NovelRepository {
-
   async getNovelById(novelId: number): Promise<Novel | null> {
     return await prisma.novel.findUnique({
       where: { id: novelId },
@@ -102,17 +101,28 @@ export class PrNovelRepository implements NovelRepository {
     return await prisma.novel.findMany();
   }
 
-  async getNovelsBySearch(searchQuery: string, filter: string, novelIds: number[], userIds : string[]): Promise<Novel[]> {
+  async getNovelsBySearch(
+    searchQuery: string,
+    filter: string,
+    novelIds: number[],
+    userIds: string[]
+  ): Promise<Novel[]> {
     return await prisma.novel.findMany({
       where: {
         OR: [
-          filter === "title" ? { title: { contains: searchQuery, mode: "insensitive" } } : {},
-          filter === "genre" ? { id: { in: novelIds.length > 0 ? novelIds : undefined } } : {},
-          filter === "author" ? { userId: { in: userIds.length > 0 ? userIds : undefined } } : {}, 
+          filter === "title"
+            ? { title: { contains: searchQuery, mode: "insensitive" } }
+            : {},
+          filter === "genre"
+            ? { id: { in: novelIds.length > 0 ? novelIds : undefined } }
+            : {},
+          filter === "author"
+            ? { userId: { in: userIds.length > 0 ? userIds : undefined } }
+            : {},
         ],
       },
       orderBy: { createdAt: "desc" },
-    }); 
+    });
   }
 
   async getNovelCountByUserId(userId: string): Promise<number> {
@@ -121,4 +131,3 @@ export class PrNovelRepository implements NovelRepository {
     });
   }
 }
-

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,16 +1,29 @@
 import { NextRequest, NextResponse } from "next/server";
 
 const middleware = (req: NextRequest) => {
-  const publicRoutes = ["/login", "/signup", "/novel", "/community"];
-  const refreshToken = req.cookies.get("refreshToken")?.value;
+  const authRoutes: Record<string, string> = {
+    "/login": "/user/novel",
+    "/novel": "/user/novel",
+    "/community": "/user/community",
+  };
+  const publicRoutes = ["/signup"];
+
+  const accessToken = req.cookies.get("accessToken")?.value;
 
   // publicRoute에서는 다음 동작으로 넘어감
   if (publicRoutes.some((route) => req.nextUrl.pathname === route)) {
     return NextResponse.next();
   }
 
+  // 사용자가 로그인된 상태면 `/login` 페이지에서 `/user/novel`으로 리다이렉트
+  if (accessToken && authRoutes[req.nextUrl.pathname]) {
+    return NextResponse.redirect(
+      new URL(authRoutes[req.nextUrl.pathname], req.url)
+    );
+  }
+
   // 토큰이 없을 경우 로그인 페이지로 리다이렉트
-  if (!refreshToken) {
+  if (!accessToken) {
     return NextResponse.redirect(new URL("/login", req.url));
   }
 
@@ -21,5 +34,5 @@ export default middleware;
 
 // 실행될 경로 설정
 export const config = {
-  matcher: ["/user/:path*"],
+  matcher: ["/login", "/novel", "/community", "/user/:path*"],
 };

--- a/middleware.ts
+++ b/middleware.ts
@@ -7,23 +7,22 @@ const middleware = (req: NextRequest) => {
     "/community": "/user/community",
   };
   const publicRoutes = ["/signup"];
+  const currentPath = req.nextUrl.pathname;
 
   const accessToken = req.cookies.get("accessToken")?.value;
 
   // publicRoute에서는 다음 동작으로 넘어감
-  if (publicRoutes.some((route) => req.nextUrl.pathname === route)) {
+  if (publicRoutes.includes(currentPath)) {
     return NextResponse.next();
   }
 
   // 사용자가 로그인된 상태면 `/login` 페이지에서 `/user/novel`으로 리다이렉트
-  if (accessToken && authRoutes[req.nextUrl.pathname]) {
-    return NextResponse.redirect(
-      new URL(authRoutes[req.nextUrl.pathname], req.url)
-    );
+  if (accessToken && authRoutes[currentPath]) {
+    return NextResponse.redirect(new URL(authRoutes[currentPath], req.url));
   }
 
   // 토큰이 없을 경우 로그인 페이지로 리다이렉트
-  if (!accessToken) {
+  if (!accessToken && currentPath.startsWith("/user")) {
     return NextResponse.redirect(new URL("/login", req.url));
   }
 


### PR DESCRIPTION
## 🔘Part

- [x] BE

  <br/>

## 🔎 작업 내용
- 로그아웃 버튼 클릭 시 쿠키에 저장된 토큰 삭제
- db에 저장된 refresh token도 삭제
- 로그아웃 후 `/` 페이지로 리다이렉트
  <br/>

## 이미지 첨부

<br/>

## 🔧 앞으로의 과제
- 회원 탈퇴 기능 구현
- 관리자 페이지 구현

  <br/>

## ➕ 이슈 링크

- [fungle #291 ]

<br/>
