### PR TITLE
[feat]  커뮤니티 리스트 페이지 네이션 이동 시 리스트 상단으로 스크롤 이동 구현 #316

### DIFF
--- a/app/(main)/user/community/components/CommunityPostList.tsx
+++ b/app/(main)/user/community/components/CommunityPostList.tsx
@@ -18,7 +18,7 @@ import {
   EmptyStateContainer,
 } from "./CommunityPostList.styled";
 import { realTimeView } from "../utils/realTimeView";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import CommunityPostStats from "./CommunityPostStats";
 import { PostWithCountAndRecruitmentDto } from "@/application/usecases/community/dto/PostWithCountAndRecruitmentDto";
 import CommunityPagination from "./CommunityPagination";
@@ -38,6 +38,7 @@ const CommunityPostList = ({
   const [totalPages, setTotalPages] = useState(1);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const listRef = useRef<HTMLUListElement | null>(null);
 
   const hadleChangePage = (newPage: number) => {
     setSearchParams((prev) => ({ ...prev, page: newPage }));
@@ -93,6 +94,7 @@ const CommunityPostList = ({
 
         setTotalPages(data.totalPages);
         setIsLoading(false);
+        listRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
       } catch (error: unknown) {
         const errorMessage =
           error instanceof Error ? error.message : "Unknow Error";
@@ -126,7 +128,7 @@ const CommunityPostList = ({
   }
 
   return (
-    <PostListContainer>
+    <PostListContainer ref={listRef}>
       {posts.map((post) => (
         <PostListWrapper key={post.id}>
           <Link href={`/user/community/${post.id}`}>


### PR DESCRIPTION
## 🔘Part

- [x] FE

  <br/>

## 🔎 작업 내용
- 페이지 네이션 페이지 1 -> 2로 이동 시 스크롤 이동 하는 기능 구현
  <br/>

## 이미지 첨부

https://github.com/user-attachments/assets/900c83e5-61f0-403d-83b6-8419a2f5a744


<br/>

## 🔧 앞으로의 과제


  <br/>

## ➕ 이슈 링크

- [fungle #316 ]

<br/>
