### PR TITLE
[refactor] 커뮤니티 상세 페이지 CSR로 변경 #326

### DIFF
--- a/app/(main)/user/community/[id]/page.tsx
+++ b/app/(main)/user/community/[id]/page.tsx
@@ -1,44 +1,60 @@
+"use client";
 import { Main } from "./CommunityDetailPage.styled";
 
 import CommunityPostHeader from "./components/CommunityPostHeader";
 import CommunityPostContent from "./components/CommunityPostContent";
 import CommentHeader from "@/components/comment/CommentHeader";
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import Loading from "./loading";
+import { CommunityPost } from "@prisma/client";
+export type CommunityDetailPostType = CommunityPost & {
+  userNickname: string;
+  likes: number;
+  likedUserId: string[];
+};
+const Page = () => {
+  const [post, setPost] = useState<CommunityDetailPostType | null>(null);
+  const [errorMessage, setErrorMessage] = useState("");
+  const params = useParams();
+  const postId = params.id;
 
-interface PageParams {
-  params: Promise<{ id: string }>;
-}
+  useEffect(() => {
+    const fetchDetailPage = async () => {
+      try {
+        const response = await fetch(`/api/community/${postId}`);
 
-const Page = async ({ params }: PageParams) => {
-  const postId = (await params).id;
+        if (!response.ok) {
+          throw new Error(`서버 연결 실패: ${response.status}`);
+        }
 
-  let post;
-  try {
-    const response = await fetch(
-      `${process.env.NEXT_PUBLIC_BASE_URL}/api/community/${postId}`,
-      {
-        cache: "no-store",
+        const post = await response.json();
+        setPost(post);
+      } catch (error: unknown) {
+        let message = "게시글을 찾는 중 알 수 없는 오류가 발생했습니다.";
+        if (error instanceof Error) {
+          message = error.message;
+        }
+        setErrorMessage(message);
       }
-    );
+    };
 
-    if (!response.ok) {
-      throw new Error(`Failed to fetch post: ${response.status}`);
-    }
+    fetchDetailPage();
+  }, [postId]);
 
-    post = await response.json();
-  } catch (error: unknown) {
-    let errorMessage = "게시글을 찾는 중 알 수 없는 오류가 발생했습니다.";
-    if (error instanceof Error) {
-      errorMessage = error.message;
-    }
-    return <main>{errorMessage}</main>;
-  }
   return (
     <Main>
-      <CommunityPostHeader postDetail={post} />
-
-      <CommunityPostContent postDetail={post} />
-
-      <CommentHeader post={post} />
+      {errorMessage ? (
+        <main>{errorMessage}</main>
+      ) : !post ? (
+        <Loading />
+      ) : (
+        <>
+          <CommunityPostHeader postDetail={post} />
+          <CommunityPostContent postDetail={post} />
+          <CommentHeader post={post} />
+        </>
+      )}
     </Main>
   );
 };

--- a/app/(main)/user/community/components/CommunityPostList.tsx
+++ b/app/(main)/user/community/components/CommunityPostList.tsx
@@ -42,6 +42,7 @@ const CommunityPostList = ({
 
   const hadleChangePage = (newPage: number) => {
     setSearchParams((prev) => ({ ...prev, page: newPage }));
+    listRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
   };
 
   useEffect(() => {
@@ -94,7 +95,6 @@ const CommunityPostList = ({
 
         setTotalPages(data.totalPages);
         setIsLoading(false);
-        listRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
       } catch (error: unknown) {
         const errorMessage =
           error instanceof Error ? error.message : "Unknow Error";

--- a/app/(main)/user/community/components/CommunitySearchFilter.tsx
+++ b/app/(main)/user/community/components/CommunitySearchFilter.tsx
@@ -70,7 +70,7 @@ const CommunitySearchFilter = ({ onSearch }: CommunitySearchFilterProps) => {
   const handleRecruitmentSelect = (value: string) => {
     const option = RECRUITMENT_FIELDS.find((opt) => opt.value === value);
     if (!option) return;
-    // 토글 방식: 이미 있다면 제거, 없으면 추가
+
     if (searchRecruitment.includes(option.label)) {
       setSearchRecruitment(
         searchRecruitment.filter((label) => label !== option.label)

--- a/infrastructure/repositories/PrCommunityPostRepository.ts
+++ b/infrastructure/repositories/PrCommunityPostRepository.ts
@@ -18,7 +18,13 @@ export class PrCommunityPostRepository implements CommunityPostRepository {
     recruitment?: string;
   }): Promise<PostWithRelations[]> {
     const whereClause: Prisma.CommunityPostWhereInput = {};
-
+    const recruitmentMap: Record<string, string> = {
+      디자이너: "designer",
+      작가: "writer",
+      편집자: "editor",
+      기획자: "planner",
+    };
+    console.log("infra ", params.recruitment);
     if (params.filter !== "all") {
       whereClause.status = params.filter;
     }
@@ -40,11 +46,12 @@ export class PrCommunityPostRepository implements CommunityPostRepository {
       }
     }
 
-    if (params.recruitment?.trim() !== "") {
+    if (params.recruitment) {
+      const recruitmentEng = recruitmentMap[params.recruitment];
       whereClause.PostRecruitments = {
         some: {
           RecruitmentCategory: {
-            name: { contains: params.recruitment, mode: "insensitive" },
+            name: { contains: recruitmentEng, mode: "insensitive" },
           },
         },
       };


### PR DESCRIPTION
## 🔘Part

- [x] FE
- [x] BE
  <br/>

## 🔎 작업 내용
- 커뮤니티 상세 페이지 기존 SSR -> CSR로 변경
- 커뮤니티 리스트 모집분야 필터링 클라이언트에선 한글로 전달, 데이터베이스는 영어로 저장으로 인해 infrastructure 단에서 영어로 맵핑 하는 작업 추가
- 페이지 네이션 할때만 스크롤 이동으로 변경 기존 필터링 할때도 이동하였음
  <br/>

## 이미지 첨부

<br/>

## 🔧 앞으로의 과제


  <br/>

## ➕ 이슈 링크

- [fungle #326 ]

<br/>
